### PR TITLE
update pay sequencer fees

### DIFF
--- a/main/main.zkasm
+++ b/main/main.zkasm
@@ -76,25 +76,6 @@ processTxEnd:
 processTxsEnd: 
 
 
-;;;;;;;
-; Pay Fees to sequencer
-;;;;;;;
-
-        $ => D                          :MLOAD(sequencerAccValue)
-
-        $ => A                          :MLOAD(sequencerAddr)
-        0 => B,C
-        $ => A                          :SLOAD                                                  ; Original Balance in A
-
-        1 => B
-        D => C
-        0 => D
-        ${A+C} => D                     :ARITH                                                   ; New Balance in D
-
-        $ => A                          :MLOAD(sequencerAddr)
-        0 => B,C
-        $ => SR                         :SSTORE
-
 ;;;;;;;;
 ; Get Signed TXs
 ;;;;;;;

--- a/main/process_tx.zkasm
+++ b/main/process_tx.zkasm
@@ -188,12 +188,20 @@ endCheckChainId:
         $ => B                          :MLOAD(txGasPrice)
         0 => C                          
         0 => D                                                                                  ; Forces no overflow 
-        ${A*B} => C                     :ARITH                                                  ; valueToAccumulate in C
+        ${A*B} => D                     :ARITH                                                  ; value to pay the sequencer in D
 
-        $ => A                          :MLOAD(sequencerAccValue)
+        $ => A                          :MLOAD(sequencerAddr)
+        0 => B,C
+        $ => A                          :SLOAD                                                  ; Original Balance in A
+
         1 => B
+        D => C
         0 => D
-        ${A+C} => A                     :ARITH, MSTORE(sequencerAccValue)                                                
+        ${A+C} => D                     :ARITH                                                   ; New Balance in D
+
+        $ => A                          :MLOAD(sequencerAddr)
+        0 => B,C
+        $ => SR                         :SSTORE                                         
 
 
 terminateTX:

--- a/main/vars.zkasm
+++ b/main/vars.zkasm
@@ -6,7 +6,6 @@ VAR GLOBAL lastCtxUsed
 VAR GLOBAL firstCtxUsed
 VAR GLOBAL lastHashIdUsed
 VAR GLOBAL sequencerAddr
-VAR GLOBAL sequencerAccValue
 VAR GLOBAL chainId
 VAR GLOBAL defaultChainId
 VAR GLOBAL oldLocalExitRoot


### PR DESCRIPTION
- Fees should be payed to the sequencer and updated in the state at the end of every transaction.