### PR TITLE
Fix 32 bytes

### DIFF
--- a/main/loadtx_rlp.zkasm
+++ b/main/loadtx_rlp.zkasm
@@ -1,10 +1,9 @@
 
 loadTx_rlp:
 
-        ; We get a new hashId and store it in txHashId
+        ; We get a new hashId
         $ => E                          :MLOAD(lastHashIdUsed)
         E+1 => E                        :MSTORE(lastHashIdUsed)
-        E                               :MSTORE(txHashId)
         0 => C
 
         $${p = 0}
@@ -46,7 +45,7 @@ nonceREAD:
         A                               :HASHW(E)    ; Main Hash
         C + D => C
         A - 0x80                        :JMPC(endNonce)
-        A - 0xb8                        :JMPC(shortNonce)
+        A - 0x89                        :JMPC(shortNonce)
                                         :JMP(invalidTxRLP)
 shortNonce:
         A - 0x80 => D
@@ -72,7 +71,7 @@ gasPriceREAD:
         C + D => C
 
         A - 0x80                        :JMPC(endGasPrice)
-        A - 0xb8                        :JMPC(shortGasPrice)
+        A - 0xa1                        :JMPC(shortGasPrice)
                                         :JMP(invalidTxRLP)
 shortGasPrice:
         A - 0x80 => D
@@ -98,7 +97,7 @@ gasREAD:
         A                               :HASHW(E)    ; Main Hash
         C + D => C
         A - 0x80                        :JMPC(endGas)
-        A - 0xb8                        :JMPC(shortGas)
+        A - 0xa1                        :JMPC(shortGas)
                                         :JMP(invalidTxRLP)
 shortGas:
         A - 0x80 => D
@@ -157,7 +156,7 @@ valueREAD:
         C + D => C
 
         A - 0x80                        :JMPC(endValue)
-        A - 0xb8                        :JMPC(shortValue)
+        A - 0xa1                        :JMPC(shortValue)
                                         :JMP(invalidTxRLP)
 shortValue:
         A - 0x80 => D
@@ -245,7 +244,7 @@ chainREAD:
         A                               :HASHW(E)    ; Main Hash
         C+D => C
         A - 0x80                        :JMPC(endChainId)
-        A - 0xb8                        :JMPC(shortChainId)
+        A - 0x89                        :JMPC(shortChainId)
                                         :JMP(invalidTxRLP)
 shortChainId:
         A - 0x80 => D

--- a/main/main.zkasm
+++ b/main/main.zkasm
@@ -98,10 +98,9 @@ processTxsEnd:
 ;;;;;;;;
 ; Get Signed TXs
 ;;;;;;;
-        ; We get a new hashId and store it in txHashId
+        ; We get a new hashId
         $ => E                          :MLOAD(lastHashIdUsed)
         E+1 => E                        :MSTORE(lastHashIdUsed)
-        E                               :MSTORE(txHashId) ; todo check needed
 
 ;;;;;;;;;
 ;; Append TXs

--- a/main/process_tx.zkasm
+++ b/main/process_tx.zkasm
@@ -1,10 +1,9 @@
 
 processTx:
 
-        ; We get a new hashId and store it in txHashId
+        ; We get a new hashId
         $ => E                          :MLOAD(lastHashIdUsed)
         E+1 => E                        :MSTORE(lastHashIdUsed)
-        E                               :MSTORE(txHashId)
         0 => C
 
 ;;;;;;;;;

--- a/main/vars.zkasm
+++ b/main/vars.zkasm
@@ -17,7 +17,6 @@ VAR GLOBAL newStateRoot
 VAR GLOBAL batchHashData
 VAR GLOBAL globalExitRoot
 
-VAR CTX txHashId
 VAR CTX txGas
 VAR CTX txDestAddr
 VAR CTX txValue


### PR DESCRIPTION
Add maximum field length check:
- `nonce`: 8 bytes
- `gasPrice`: 32 bytes
- `gasLimit`: 32 bytes
- `value`: 32 bytes
- `chainId`: 8 bytes
If the maximum length is exceeded, it will be invalidated as an invalid RLP.