### PR TITLE
fix SP, BYTE, SHR, SHL

### DIFF
--- a/build/rom.json
+++ b/build/rom.json
@@ -7463,6 +7463,13 @@
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
+   "inGAS": "1",
+   "CONST": "-3",
+   "setGAS": 1,
+   "line": 191,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
    "freeInTag": {
     "op": "functionCall",
     "funcName": "bitwise_and",
@@ -7486,13 +7493,13 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 191,
+   "line": 192,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
    "offset": 478,
-   "line": 192,
+   "line": 193,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -7500,7 +7507,7 @@
    "inSP": "1",
    "CONST": "-1",
    "setSP": 1,
-   "line": 195,
+   "line": 196,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -7518,7 +7525,7 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 196,
+   "line": 197,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -7536,7 +7543,14 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 197,
+   "line": 198,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "inGAS": "1",
+   "CONST": "-3",
+   "setGAS": 1,
+   "line": 199,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -7563,13 +7577,13 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 198,
+   "line": 200,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
    "offset": 478,
-   "line": 199,
+   "line": 201,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -7577,7 +7591,7 @@
    "inSP": "1",
    "CONST": "-1",
    "setSP": 1,
-   "line": 202,
+   "line": 204,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -7595,7 +7609,7 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 203,
+   "line": 205,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -7613,7 +7627,14 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 204,
+   "line": 206,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "inGAS": "1",
+   "CONST": "-3",
+   "setGAS": 1,
+   "line": 207,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -7640,13 +7661,13 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 205,
+   "line": 208,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
    "offset": 478,
-   "line": 206,
+   "line": 209,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -7654,7 +7675,7 @@
    "inSP": "1",
    "CONST": "-1",
    "setSP": 1,
-   "line": 209,
+   "line": 212,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -7668,29 +7689,18 @@
    "isMem": 0,
    "ind": 0,
    "incCode": 0,
-   "incStack": -1,
-   "offset": 0,
-   "useCTX": 1,
-   "mRD": 1,
-   "line": 210,
-   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
-  },
-  {
-   "freeInTag": {
-    "op": ""
-   },
-   "inFREE": "1",
-   "setB": 1,
-   "isStack": 1,
-   "isCode": 0,
-   "isMem": 0,
-   "ind": 0,
-   "incCode": 0,
    "incStack": 0,
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 211,
+   "line": 213,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "inGAS": "1",
+   "CONST": "-3",
+   "setGAS": 1,
+   "line": 214,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -7713,13 +7723,13 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 212,
+   "line": 215,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
    "offset": 478,
-   "line": 213,
+   "line": 216,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -7727,7 +7737,25 @@
    "inSP": "1",
    "CONST": "-1",
    "setSP": 1,
-   "line": 216,
+   "line": 219,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "freeInTag": {
+    "op": ""
+   },
+   "inFREE": "1",
+   "setB": 1,
+   "isStack": 1,
+   "isCode": 0,
+   "isMem": 0,
+   "ind": 0,
+   "incCode": 0,
+   "incStack": -1,
+   "offset": 0,
+   "useCTX": 1,
+   "mRD": 1,
+   "line": 220,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -7741,36 +7769,18 @@
    "isMem": 0,
    "ind": 0,
    "incCode": 0,
-   "incStack": -1,
-   "offset": 0,
-   "useCTX": 1,
-   "mRD": 1,
-   "line": 217,
-   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
-  },
-  {
-   "freeInTag": {
-    "op": ""
-   },
-   "inFREE": "1",
-   "setB": 1,
-   "isStack": 1,
-   "isCode": 0,
-   "isMem": 0,
-   "ind": 0,
-   "incCode": 0,
    "incStack": 0,
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 218,
+   "line": 221,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "CONST": "31",
    "inB": "-1",
    "setD": 1,
-   "line": 219,
+   "line": 222,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -7780,7 +7790,14 @@
    "inFREE": "1",
    "setB": 1,
    "shr": 1,
-   "line": 220,
+   "line": 223,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "inGAS": "1",
+   "CONST": "-3",
+   "setGAS": 1,
+   "line": 224,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -7807,13 +7824,13 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 221,
+   "line": 225,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
    "offset": 478,
-   "line": 222,
+   "line": 226,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -7821,7 +7838,7 @@
    "inSP": "1",
    "CONST": "-1",
    "setSP": 1,
-   "line": 225,
+   "line": 229,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -7839,7 +7856,7 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 226,
+   "line": 230,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -7858,7 +7875,7 @@
    },
    "inFREE": "1",
    "setD": 1,
-   "line": 227,
+   "line": 231,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -7876,7 +7893,7 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 228,
+   "line": 232,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -7886,7 +7903,7 @@
    "inFREE": "1",
    "setA": 1,
    "shr": 1,
-   "line": 229,
+   "line": 233,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -7899,20 +7916,20 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 230,
+   "line": 234,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inGAS": "1",
    "CONST": "-3",
    "setGAS": 1,
-   "line": 231,
+   "line": 235,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
    "offset": 478,
-   "line": 232,
+   "line": 236,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -7920,7 +7937,7 @@
    "inSP": "1",
    "CONST": "-1",
    "setSP": 1,
-   "line": 235,
+   "line": 239,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -7938,7 +7955,7 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 236,
+   "line": 240,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -7957,7 +7974,7 @@
    },
    "inFREE": "1",
    "setD": 1,
-   "line": 237,
+   "line": 241,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -7975,7 +7992,7 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 238,
+   "line": 242,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -7985,7 +8002,7 @@
    "inFREE": "1",
    "setA": 1,
    "shl": 1,
-   "line": 239,
+   "line": 243,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -7998,20 +8015,20 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 240,
+   "line": 244,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inGAS": "1",
    "CONST": "-3",
    "setGAS": 1,
-   "line": 241,
+   "line": 245,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
    "offset": 478,
-   "line": 242,
+   "line": 246,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -8023,7 +8040,7 @@
    "setA": 1,
    "offset": 2,
    "mRD": 1,
-   "line": 263,
+   "line": 267,
    "offsetLabel": "txValue",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -8038,20 +8055,20 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 264,
+   "line": 268,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inGAS": "1",
    "CONST": "-2",
    "setGAS": 1,
-   "line": 265,
+   "line": 269,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
    "offset": 478,
-   "line": 266,
+   "line": 270,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -8059,7 +8076,7 @@
    "inSP": "1",
    "CONST": "-1",
    "setSP": 1,
-   "line": 269,
+   "line": 273,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -8077,7 +8094,7 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 270,
+   "line": 274,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -8096,7 +8113,7 @@
    },
    "inFREE": "1",
    "setB": 1,
-   "line": 271,
+   "line": 275,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -8115,29 +8132,29 @@
    },
    "inFREE": "1",
    "setA": 1,
-   "line": 272,
+   "line": 276,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "CONST": "0",
    "inA": "-1",
    "JMPC": 1,
-   "offset": 720,
-   "line": 273,
+   "offset": 724,
+   "line": 277,
    "offsetLabel": "opCALLDATALOAD2",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inSP": "1",
    "setC": 1,
-   "line": 274,
+   "line": 278,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "CONST": "1024",
    "inB": "1",
    "setSP": 1,
-   "line": 275,
+   "line": 279,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -8155,13 +8172,13 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 276,
+   "line": 280,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inC": "1",
    "setSP": 1,
-   "line": 277,
+   "line": 281,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -8174,91 +8191,39 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 278,
+   "line": 282,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inGAS": "1",
    "CONST": "-3",
    "setGAS": 1,
-   "line": 279,
+   "line": 283,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
    "offset": 478,
-   "line": 280,
+   "line": 284,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inSP": "1",
    "setC": 1,
-   "line": 283,
+   "line": 287,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inA": "1",
    "setD": 1,
-   "line": 284,
+   "line": 288,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "CONST": "1024",
    "inB": "1",
    "setSP": 1,
-   "line": 285,
-   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
-  },
-  {
-   "freeInTag": {
-    "op": ""
-   },
-   "inFREE": "1",
-   "setA": 1,
-   "isStack": 1,
-   "isCode": 0,
-   "isMem": 0,
-   "ind": 0,
-   "incStack": 1,
-   "offset": 0,
-   "useCTX": 1,
-   "mRD": 1,
-   "line": 286,
-   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
-  },
-  {
-   "freeInTag": {
-    "op": ""
-   },
-   "inFREE": "1",
-   "setB": 1,
-   "shl": 1,
-   "line": 287,
-   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
-  },
-  {
-   "CONST": "32",
-   "inD": "-1",
-   "setD": 1,
-   "line": 288,
-   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
-  },
-  {
-   "freeInTag": {
-    "op": ""
-   },
-   "inFREE": "1",
-   "setA": 1,
-   "isStack": 1,
-   "isCode": 0,
-   "isMem": 0,
-   "ind": 0,
-   "incCode": 0,
-   "incStack": 0,
-   "offset": 0,
-   "useCTX": 1,
-   "mRD": 1,
    "line": 289,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -8268,14 +8233,66 @@
    },
    "inFREE": "1",
    "setA": 1,
-   "shr": 1,
+   "isStack": 1,
+   "isCode": 0,
+   "isMem": 0,
+   "ind": 0,
+   "incStack": 1,
+   "offset": 0,
+   "useCTX": 1,
+   "mRD": 1,
    "line": 290,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "freeInTag": {
+    "op": ""
+   },
+   "inFREE": "1",
+   "setB": 1,
+   "shl": 1,
+   "line": 291,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "CONST": "32",
+   "inD": "-1",
+   "setD": 1,
+   "line": 292,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "freeInTag": {
+    "op": ""
+   },
+   "inFREE": "1",
+   "setA": 1,
+   "isStack": 1,
+   "isCode": 0,
+   "isMem": 0,
+   "ind": 0,
+   "incCode": 0,
+   "incStack": 0,
+   "offset": 0,
+   "useCTX": 1,
+   "mRD": 1,
+   "line": 293,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "freeInTag": {
+    "op": ""
+   },
+   "inFREE": "1",
+   "setA": 1,
+   "shr": 1,
+   "line": 294,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inC": "1",
    "setSP": 1,
-   "line": 291,
+   "line": 295,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -8289,60 +8306,20 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 292,
+   "line": 296,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inGAS": "1",
    "CONST": "-3",
    "setGAS": 1,
-   "line": 293,
-   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
-  },
-  {
-   "JMP": 1,
-   "offset": 478,
-   "line": 294,
-   "offsetLabel": "readCode",
-   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
-  },
-  {
-   "freeInTag": {
-    "op": ""
-   },
-   "inFREE": "1",
-   "setB": 1,
-   "offset": 6,
-   "mRD": 1,
    "line": 297,
-   "offsetLabel": "txNData",
-   "useCTX": 1,
-   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
-  },
-  {
-   "inB": "1",
-   "isStack": 1,
-   "isCode": 0,
-   "isMem": 0,
-   "ind": 0,
-   "incStack": 1,
-   "offset": 0,
-   "useCTX": 1,
-   "mWR": 1,
-   "line": 298,
-   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
-  },
-  {
-   "inGAS": "1",
-   "CONST": "-2",
-   "setGAS": 1,
-   "line": 299,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
    "offset": 478,
-   "line": 300,
+   "line": 298,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -8354,7 +8331,7 @@
    "setB": 1,
    "offset": 6,
    "mRD": 1,
-   "line": 309,
+   "line": 301,
    "offsetLabel": "txNData",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -8369,20 +8346,60 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 310,
+   "line": 302,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inGAS": "1",
    "CONST": "-2",
    "setGAS": 1,
-   "line": 311,
+   "line": 303,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
    "offset": 478,
-   "line": 312,
+   "line": 304,
+   "offsetLabel": "readCode",
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "freeInTag": {
+    "op": ""
+   },
+   "inFREE": "1",
+   "setB": 1,
+   "offset": 6,
+   "mRD": 1,
+   "line": 313,
+   "offsetLabel": "txNData",
+   "useCTX": 1,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "inB": "1",
+   "isStack": 1,
+   "isCode": 0,
+   "isMem": 0,
+   "ind": 0,
+   "incStack": 1,
+   "offset": 0,
+   "useCTX": 1,
+   "mWR": 1,
+   "line": 314,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "inGAS": "1",
+   "CONST": "-2",
+   "setGAS": 1,
+   "line": 315,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "JMP": 1,
+   "offset": 478,
+   "line": 316,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -8390,7 +8407,7 @@
    "inSP": "1",
    "CONST": "-1",
    "setSP": 1,
-   "line": 315,
+   "line": 319,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -8408,7 +8425,7 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 316,
+   "line": 320,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -8426,7 +8443,7 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 317,
+   "line": 321,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -8444,7 +8461,7 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 318,
+   "line": 322,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -8452,7 +8469,7 @@
    "inC": "1",
    "offset": 23,
    "mWR": 1,
-   "line": 319,
+   "line": 323,
    "offsetLabel": "lastMemLength",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -8461,7 +8478,7 @@
    "inGAS": "1",
    "CONST": "-3",
    "setGAS": 1,
-   "line": 320,
+   "line": 324,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -8499,22 +8516,22 @@
    },
    "inFREE": "-1",
    "setGAS": 1,
-   "line": 321,
+   "line": 325,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inSP": "1",
    "offset": 9,
    "mWR": 1,
-   "line": 322,
+   "line": 326,
    "offsetLabel": "SPw",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 749,
-   "line": 323,
+   "offset": 753,
+   "line": 327,
    "offsetLabel": "opCODECOPY1",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -8522,8 +8539,8 @@
    "inC": "1",
    "CONST": "-1",
    "JMPC": 1,
-   "offset": 784,
-   "line": 326,
+   "offset": 788,
+   "line": 330,
    "offsetLabel": "opCODECOPYend",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -8531,8 +8548,8 @@
    "inC": "1",
    "CONST": "-32",
    "JMPC": 1,
-   "offset": 767,
-   "line": 327,
+   "offset": 771,
+   "line": 331,
    "offsetLabel": "opCODECOPYfinal",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -8552,7 +8569,7 @@
    },
    "inFREE": "1",
    "setD": 1,
-   "line": 328,
+   "line": 332,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -8572,61 +8589,6 @@
    },
    "inFREE": "1",
    "setSP": 1,
-   "line": 329,
-   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
-  },
-  {
-   "freeInTag": {
-    "op": ""
-   },
-   "inFREE": "1",
-   "setA": 1,
-   "isStack": 1,
-   "isCode": 0,
-   "isMem": 0,
-   "ind": 0,
-   "incCode": 0,
-   "incStack": 0,
-   "offset": 0,
-   "useCTX": 1,
-   "mRD": 1,
-   "line": 330,
-   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
-  },
-  {
-   "freeInTag": {
-    "op": ""
-   },
-   "inFREE": "1",
-   "setC": 1,
-   "shl": 1,
-   "line": 331,
-   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
-  },
-  {
-   "CONST": "1025",
-   "freeInTag": {
-    "op": "div",
-    "values": [
-     {
-      "op": "getReg",
-      "regName": "B"
-     },
-     {
-      "op": "number",
-      "num": "32"
-     }
-    ]
-   },
-   "inFREE": "1",
-   "setSP": 1,
-   "line": 332,
-   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
-  },
-  {
-   "CONST": "32",
-   "inD": "-1",
-   "setD": 1,
    "line": 333,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -8653,195 +8615,9 @@
     "op": ""
    },
    "inFREE": "1",
-   "setA": 1,
-   "shr": 1,
-   "line": 335,
-   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
-  },
-  {
-   "inA": "1",
-   "inC": "1",
-   "isStack": 0,
-   "isMem": 1,
-   "isCode": 0,
-   "ind": 1,
-   "incCode": 0,
-   "incStack": 0,
-   "offset": 0,
-   "useCTX": 1,
-   "mWR": 1,
-   "line": 336,
-   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
-  },
-  {
-   "inE": "1",
-   "CONST": "1",
-   "setE": 1,
-   "line": 337,
-   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
-  },
-  {
-   "freeInTag": {
-    "op": ""
-   },
-   "inFREE": "1",
-   "setSP": 1,
-   "offset": 9,
-   "mRD": 1,
-   "line": 338,
-   "offsetLabel": "SPw",
-   "useCTX": 1,
-   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
-  },
-  {
-   "freeInTag": {
-    "op": ""
-   },
-   "inFREE": "1",
    "setC": 1,
-   "isStack": 1,
-   "isCode": 0,
-   "isMem": 0,
-   "ind": 0,
-   "incCode": 0,
-   "incStack": 0,
-   "offset": 0,
-   "useCTX": 1,
-   "mRD": 1,
-   "line": 339,
-   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
-  },
-  {
-   "inC": "1",
-   "CONST": "-32",
-   "setC": 1,
-   "line": 340,
-   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
-  },
-  {
-   "inC": "1",
-   "isStack": 1,
-   "isCode": 0,
-   "isMem": 0,
-   "ind": 0,
-   "incCode": 0,
-   "incStack": 0,
-   "offset": 0,
-   "useCTX": 1,
-   "mWR": 1,
-   "line": 341,
-   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
-  },
-  {
-   "inB": "1",
-   "CONST": "32",
-   "setB": 1,
-   "line": 342,
-   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
-  },
-  {
-   "JMP": 1,
-   "offset": 749,
-   "line": 343,
-   "offsetLabel": "opCODECOPY1",
-   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
-  },
-  {
-   "freeInTag": {
-    "op": "mod",
-    "values": [
-     {
-      "op": "getReg",
-      "regName": "B"
-     },
-     {
-      "op": "number",
-      "num": "32"
-     }
-    ]
-   },
-   "inFREE": "1",
-   "setD": 1,
-   "line": 346,
-   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
-  },
-  {
-   "CONST": "1024",
-   "freeInTag": {
-    "op": "div",
-    "values": [
-     {
-      "op": "getReg",
-      "regName": "B"
-     },
-     {
-      "op": "number",
-      "num": "32"
-     }
-    ]
-   },
-   "inFREE": "1",
-   "setSP": 1,
-   "line": 347,
-   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
-  },
-  {
-   "freeInTag": {
-    "op": ""
-   },
-   "inFREE": "1",
-   "setA": 1,
-   "isStack": 1,
-   "isCode": 0,
-   "isMem": 0,
-   "ind": 0,
-   "incCode": 0,
-   "incStack": 0,
-   "offset": 0,
-   "useCTX": 1,
-   "mRD": 1,
-   "line": 348,
-   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
-  },
-  {
-   "freeInTag": {
-    "op": ""
-   },
-   "inFREE": "1",
-   "setA": 1,
    "shl": 1,
-   "line": 349,
-   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
-  },
-  {
-   "freeInTag": {
-    "op": ""
-   },
-   "inFREE": "1",
-   "setSP": 1,
-   "offset": 9,
-   "mRD": 1,
-   "line": 350,
-   "offsetLabel": "SPw",
-   "useCTX": 1,
-   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
-  },
-  {
-   "freeInTag": {
-    "op": ""
-   },
-   "inFREE": "1",
-   "setC": 1,
-   "isStack": 1,
-   "isCode": 0,
-   "isMem": 0,
-   "ind": 0,
-   "incCode": 0,
-   "incStack": 0,
-   "offset": 0,
-   "useCTX": 1,
-   "mRD": 1,
-   "line": 351,
+   "line": 335,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -8861,29 +8637,14 @@
    },
    "inFREE": "1",
    "setSP": 1,
-   "line": 352,
+   "line": 336,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
-   "inC": "1",
-   "CONST": "-32",
-   "inD": "1",
+   "CONST": "32",
+   "inD": "-1",
    "setD": 1,
-   "line": 353,
-   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
-  },
-  {
-   "inD": "1",
-   "JMPC": 1,
-   "offset": 783,
-   "line": 354,
-   "offsetLabel": "opCODECOPYxor",
-   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
-  },
-  {
-   "inA": "1",
-   "setC": 1,
-   "line": 355,
+   "line": 337,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -8901,7 +8662,7 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 356,
+   "line": 338,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -8911,14 +8672,270 @@
    "inFREE": "1",
    "setA": 1,
    "shr": 1,
+   "line": 339,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "inA": "1",
+   "inC": "1",
+   "isStack": 0,
+   "isMem": 1,
+   "isCode": 0,
+   "ind": 1,
+   "incCode": 0,
+   "incStack": 0,
+   "offset": 0,
+   "useCTX": 1,
+   "mWR": 1,
+   "line": 340,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "inE": "1",
+   "CONST": "1",
+   "setE": 1,
+   "line": 341,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "freeInTag": {
+    "op": ""
+   },
+   "inFREE": "1",
+   "setSP": 1,
+   "offset": 9,
+   "mRD": 1,
+   "line": 342,
+   "offsetLabel": "SPw",
+   "useCTX": 1,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "freeInTag": {
+    "op": ""
+   },
+   "inFREE": "1",
+   "setC": 1,
+   "isStack": 1,
+   "isCode": 0,
+   "isMem": 0,
+   "ind": 0,
+   "incCode": 0,
+   "incStack": 0,
+   "offset": 0,
+   "useCTX": 1,
+   "mRD": 1,
+   "line": 343,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "inC": "1",
+   "CONST": "-32",
+   "setC": 1,
+   "line": 344,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "inC": "1",
+   "isStack": 1,
+   "isCode": 0,
+   "isMem": 0,
+   "ind": 0,
+   "incCode": 0,
+   "incStack": 0,
+   "offset": 0,
+   "useCTX": 1,
+   "mWR": 1,
+   "line": 345,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "inB": "1",
+   "CONST": "32",
+   "setB": 1,
+   "line": 346,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "JMP": 1,
+   "offset": 753,
+   "line": 347,
+   "offsetLabel": "opCODECOPY1",
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "freeInTag": {
+    "op": "mod",
+    "values": [
+     {
+      "op": "getReg",
+      "regName": "B"
+     },
+     {
+      "op": "number",
+      "num": "32"
+     }
+    ]
+   },
+   "inFREE": "1",
+   "setD": 1,
+   "line": 350,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "CONST": "1024",
+   "freeInTag": {
+    "op": "div",
+    "values": [
+     {
+      "op": "getReg",
+      "regName": "B"
+     },
+     {
+      "op": "number",
+      "num": "32"
+     }
+    ]
+   },
+   "inFREE": "1",
+   "setSP": 1,
+   "line": 351,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "freeInTag": {
+    "op": ""
+   },
+   "inFREE": "1",
+   "setA": 1,
+   "isStack": 1,
+   "isCode": 0,
+   "isMem": 0,
+   "ind": 0,
+   "incCode": 0,
+   "incStack": 0,
+   "offset": 0,
+   "useCTX": 1,
+   "mRD": 1,
+   "line": 352,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "freeInTag": {
+    "op": ""
+   },
+   "inFREE": "1",
+   "setA": 1,
+   "shl": 1,
+   "line": 353,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "freeInTag": {
+    "op": ""
+   },
+   "inFREE": "1",
+   "setSP": 1,
+   "offset": 9,
+   "mRD": 1,
+   "line": 354,
+   "offsetLabel": "SPw",
+   "useCTX": 1,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "freeInTag": {
+    "op": ""
+   },
+   "inFREE": "1",
+   "setC": 1,
+   "isStack": 1,
+   "isCode": 0,
+   "isMem": 0,
+   "ind": 0,
+   "incCode": 0,
+   "incStack": 0,
+   "offset": 0,
+   "useCTX": 1,
+   "mRD": 1,
+   "line": 355,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "CONST": "1025",
+   "freeInTag": {
+    "op": "div",
+    "values": [
+     {
+      "op": "getReg",
+      "regName": "B"
+     },
+     {
+      "op": "number",
+      "num": "32"
+     }
+    ]
+   },
+   "inFREE": "1",
+   "setSP": 1,
+   "line": 356,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "inC": "1",
+   "CONST": "-32",
+   "inD": "1",
+   "setD": 1,
    "line": 357,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "inD": "1",
+   "JMPC": 1,
+   "offset": 787,
+   "line": 358,
+   "offsetLabel": "opCODECOPYxor",
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "inA": "1",
+   "setC": 1,
+   "line": 359,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "freeInTag": {
+    "op": ""
+   },
+   "inFREE": "1",
+   "setA": 1,
+   "isStack": 1,
+   "isCode": 0,
+   "isMem": 0,
+   "ind": 0,
+   "incCode": 0,
+   "incStack": 0,
+   "offset": 0,
+   "useCTX": 1,
+   "mRD": 1,
+   "line": 360,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "freeInTag": {
+    "op": ""
+   },
+   "inFREE": "1",
+   "setA": 1,
+   "shr": 1,
+   "line": 361,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inC": "1",
    "inA": "1",
    "setA": 1,
-   "line": 358,
+   "line": 362,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -8932,20 +8949,20 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 359,
+   "line": 363,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inE": "1",
    "CONST": "1",
    "setE": 1,
-   "line": 360,
+   "line": 364,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 784,
-   "line": 361,
+   "offset": 788,
+   "line": 365,
    "offsetLabel": "opCODECOPYend",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -8960,7 +8977,7 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 364,
+   "line": 368,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -8971,7 +8988,7 @@
    "setSP": 1,
    "offset": 9,
    "mRD": 1,
-   "line": 367,
+   "line": 371,
    "offsetLabel": "SPw",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -8984,7 +9001,7 @@
    "setE": 1,
    "offset": 23,
    "mRD": 1,
-   "line": 368,
+   "line": 372,
    "offsetLabel": "lastMemLength",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -8997,7 +9014,7 @@
    "setB": 1,
    "offset": 22,
    "mRD": 1,
-   "line": 369,
+   "line": 373,
    "offsetLabel": "memLength",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -9006,15 +9023,15 @@
    "inB": "1",
    "inE": "-1",
    "JMPC": 1,
-   "offset": 822,
-   "line": 370,
+   "offset": 826,
+   "line": 374,
    "offsetLabel": "saveMemLength",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
    "offset": 478,
-   "line": 371,
+   "line": 375,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -9026,7 +9043,7 @@
    "setA": 1,
    "offset": 5,
    "mRD": 1,
-   "line": 375,
+   "line": 379,
    "offsetLabel": "txGasPrice",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -9041,20 +9058,20 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 376,
+   "line": 380,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inGAS": "1",
    "CONST": "-2",
    "setGAS": 1,
-   "line": 377,
+   "line": 381,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
    "offset": 478,
-   "line": 378,
+   "line": 382,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -9066,7 +9083,7 @@
    "setA": 1,
    "offset": 0,
    "mRD": 1,
-   "line": 392,
+   "line": 396,
    "offsetLabel": "txGas",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -9081,20 +9098,20 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 393,
+   "line": 397,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inGAS": "1",
    "CONST": "-2",
    "setGAS": 1,
-   "line": 394,
+   "line": 398,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
    "offset": 478,
-   "line": 395,
+   "line": 399,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -9106,7 +9123,7 @@
    "setA": 1,
    "offset": 10,
    "mRD": 1,
-   "line": 398,
+   "line": 402,
    "offsetLabel": "txChainId",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -9121,41 +9138,20 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 399,
+   "line": 403,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inGAS": "1",
    "CONST": "-2",
    "setGAS": 1,
-   "line": 400,
+   "line": 404,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
    "offset": 478,
-   "line": 401,
-   "offsetLabel": "readCode",
-   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
-  },
-  {
-   "inSP": "1",
-   "CONST": "-1",
-   "setSP": 1,
    "line": 405,
-   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
-  },
-  {
-   "inGAS": "1",
-   "CONST": "-2",
-   "setGAS": 1,
-   "line": 406,
-   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
-  },
-  {
-   "JMP": 1,
-   "offset": 478,
-   "line": 407,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -9163,7 +9159,28 @@
    "inSP": "1",
    "CONST": "-1",
    "setSP": 1,
+   "line": 409,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "inGAS": "1",
+   "CONST": "-2",
+   "setGAS": 1,
    "line": 410,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "JMP": 1,
+   "offset": 478,
+   "line": 411,
+   "offsetLabel": "readCode",
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "inSP": "1",
+   "CONST": "-1",
+   "setSP": 1,
+   "line": 414,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -9181,7 +9198,7 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 411,
+   "line": 415,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -9199,7 +9216,7 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 412,
+   "line": 416,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -9212,14 +9229,14 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 413,
+   "line": 417,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inGAS": "1",
    "CONST": "-3",
    "setGAS": 1,
-   "line": 414,
+   "line": 418,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -9230,7 +9247,7 @@
    "setB": 1,
    "offset": 22,
    "mRD": 1,
-   "line": 415,
+   "line": 419,
    "offsetLabel": "memLength",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -9239,22 +9256,22 @@
    "inE": "1",
    "CONST": "32",
    "setE": 1,
-   "line": 416,
+   "line": 420,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inB": "1",
    "inE": "-1",
    "JMPC": 1,
-   "offset": 822,
-   "line": 418,
+   "offset": 826,
+   "line": 422,
    "offsetLabel": "saveMemLength",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
    "offset": 478,
-   "line": 419,
+   "line": 423,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -9262,7 +9279,7 @@
    "inSP": "1",
    "CONST": "-1",
    "setSP": 1,
-   "line": 422,
+   "line": 426,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -9280,7 +9297,7 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 423,
+   "line": 427,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -9298,7 +9315,7 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 424,
+   "line": 428,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -9312,14 +9329,14 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 425,
+   "line": 429,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inGAS": "1",
    "CONST": "-3",
    "setGAS": 1,
-   "line": 426,
+   "line": 430,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -9330,7 +9347,7 @@
    "setB": 1,
    "offset": 22,
    "mRD": 1,
-   "line": 427,
+   "line": 431,
    "offsetLabel": "memLength",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -9339,22 +9356,22 @@
    "inE": "1",
    "CONST": "32",
    "setE": 1,
-   "line": 428,
+   "line": 432,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inB": "1",
    "inE": "-1",
    "JMPC": 1,
-   "offset": 822,
-   "line": 430,
+   "offset": 826,
+   "line": 434,
    "offsetLabel": "saveMemLength",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
    "offset": 478,
-   "line": 431,
+   "line": 435,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -9362,7 +9379,7 @@
    "inE": "1",
    "offset": 22,
    "mWR": 1,
-   "line": 434,
+   "line": 438,
    "offsetLabel": "memLength",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -9392,7 +9409,7 @@
    },
    "inFREE": "1",
    "setA": 1,
-   "line": 435,
+   "line": 439,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -9420,7 +9437,7 @@
    },
    "inFREE": "1",
    "setB": 1,
-   "line": 436,
+   "line": 440,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -9450,7 +9467,7 @@
    },
    "inFREE": "-1",
    "setGAS": 1,
-   "line": 437,
+   "line": 441,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -9480,13 +9497,13 @@
    },
    "inFREE": "1",
    "setGAS": 1,
-   "line": 438,
+   "line": 442,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
    "offset": 478,
-   "line": 439,
+   "line": 443,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -9494,7 +9511,7 @@
    "inSP": "1",
    "CONST": "-1",
    "setSP": 1,
-   "line": 445,
+   "line": 449,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -9512,7 +9529,7 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 446,
+   "line": 450,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -9530,7 +9547,7 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 447,
+   "line": 451,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -9541,7 +9558,7 @@
    "setA": 1,
    "offset": 11,
    "mRD": 1,
-   "line": 448,
+   "line": 452,
    "offsetLabel": "txIsCreateContract",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -9550,8 +9567,8 @@
    "CONST": "0",
    "inA": "-1",
    "JMPC": 1,
-   "offset": 835,
-   "line": 449,
+   "offset": 839,
+   "line": 453,
    "offsetLabel": "deploymentSSTORE",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -9563,15 +9580,15 @@
    "setA": 1,
    "offset": 1,
    "mRD": 1,
-   "line": 450,
+   "line": 454,
    "offsetLabel": "txDestAddr",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 836,
-   "line": 451,
+   "offset": 840,
+   "line": 455,
    "offsetLabel": "opSSTOREinit",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -9583,7 +9600,7 @@
    "setA": 1,
    "offset": 12,
    "mRD": 1,
-   "line": 454,
+   "line": 458,
    "offsetLabel": "createContractAddress",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -9591,7 +9608,7 @@
   {
    "CONST": "3",
    "setB": 1,
-   "line": 457,
+   "line": 461,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -9601,14 +9618,14 @@
    "inFREE": "1",
    "setE": 1,
    "sRD": 1,
-   "line": 458,
+   "line": 462,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inSR": "1",
    "offset": 24,
    "mWR": 1,
-   "line": 459,
+   "line": 463,
    "offsetLabel": "auxSR",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -9621,7 +9638,7 @@
    "setSR": 1,
    "offset": 19,
    "mRD": 1,
-   "line": 460,
+   "line": 464,
    "offsetLabel": "initSR",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -9633,7 +9650,7 @@
    "inFREE": "1",
    "setB": 1,
    "sRD": 1,
-   "line": 461,
+   "line": 465,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -9644,7 +9661,7 @@
    "setSR": 1,
    "offset": 24,
    "mRD": 1,
-   "line": 462,
+   "line": 466,
    "offsetLabel": "auxSR",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -9667,7 +9684,7 @@
    },
    "inFREE": "-1",
    "setGAS": 1,
-   "line": 464,
+   "line": 468,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -9686,7 +9703,7 @@
     ]
    },
    "inFREE": "1",
-   "line": 465,
+   "line": 469,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -9707,8 +9724,8 @@
    "inFREE": "1",
    "CONST": "-1",
    "JMPC": 1,
-   "offset": 847,
-   "line": 466,
+   "offset": 851,
+   "line": 470,
    "offsetLabel": "opSSTOREdif",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -9716,13 +9733,13 @@
    "inGAS": "1",
    "CONST": "-100",
    "setGAS": 1,
-   "line": 468,
+   "line": 472,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 875,
-   "line": 469,
+   "offset": 879,
+   "line": 473,
    "offsetLabel": "opSSTOREend",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -9744,8 +9761,8 @@
    "inFREE": "1",
    "CONST": "-1",
    "JMPC": 1,
-   "offset": 851,
-   "line": 473,
+   "offset": 855,
+   "line": 477,
    "offsetLabel": "opSSTOREdifA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -9767,8 +9784,8 @@
    "inFREE": "1",
    "CONST": "-1",
    "JMPC": 1,
-   "offset": 870,
-   "line": 475,
+   "offset": 874,
+   "line": 479,
    "offsetLabel": "opSSTOREdifB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -9776,13 +9793,13 @@
    "inGAS": "1",
    "CONST": "-20000",
    "setGAS": 1,
-   "line": 477,
+   "line": 481,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 875,
-   "line": 478,
+   "offset": 879,
+   "line": 482,
    "offsetLabel": "opSSTOREend",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -9790,7 +9807,7 @@
    "inGAS": "1",
    "CONST": "-100",
    "setGAS": 1,
-   "line": 482,
+   "line": 486,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -9811,15 +9828,15 @@
    "inFREE": "1",
    "CONST": "-1",
    "JMPC": 1,
-   "offset": 859,
-   "line": 485,
+   "offset": 863,
+   "line": 489,
    "offsetLabel": "opSSTOREdifA1",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 854,
-   "line": 487,
+   "offset": 858,
+   "line": 491,
    "offsetLabel": "opSSTOREdifAB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -9841,8 +9858,8 @@
    "inFREE": "1",
    "CONST": "-1",
    "JMPC": 1,
-   "offset": 875,
-   "line": 490,
+   "offset": 879,
+   "line": 494,
    "offsetLabel": "opSSTOREend",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -9864,8 +9881,8 @@
    "inFREE": "1",
    "CONST": "-1",
    "JMPC": 1,
-   "offset": 867,
-   "line": 492,
+   "offset": 871,
+   "line": 496,
    "offsetLabel": "opSSTOREdifA2",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -9877,7 +9894,7 @@
    "setA": 1,
    "offset": 18,
    "mRD": 1,
-   "line": 494,
+   "line": 498,
    "offsetLabel": "gasRefund",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -9888,15 +9905,15 @@
    "setA": 1,
    "offset": 18,
    "mWR": 1,
-   "line": 495,
+   "line": 499,
    "offsetLabel": "gasRefund",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 875,
-   "line": 496,
+   "offset": 879,
+   "line": 500,
    "offsetLabel": "opSSTOREend",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -9918,8 +9935,8 @@
    "inFREE": "1",
    "CONST": "-1",
    "JMPC": 1,
-   "offset": 863,
-   "line": 500,
+   "offset": 867,
+   "line": 504,
    "offsetLabel": "opSSTOREdifA12",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -9931,7 +9948,7 @@
    "setA": 1,
    "offset": 18,
    "mRD": 1,
-   "line": 502,
+   "line": 506,
    "offsetLabel": "gasRefund",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -9942,15 +9959,15 @@
    "setA": 1,
    "offset": 18,
    "mWR": 1,
-   "line": 503,
+   "line": 507,
    "offsetLabel": "gasRefund",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 854,
-   "line": 504,
+   "offset": 858,
+   "line": 508,
    "offsetLabel": "opSSTOREdifAB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -9972,38 +9989,7 @@
    "inFREE": "1",
    "CONST": "-1",
    "JMPC": 1,
-   "offset": 854,
-   "line": 507,
-   "offsetLabel": "opSSTOREdifAB",
-   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
-  },
-  {
-   "freeInTag": {
-    "op": ""
-   },
-   "inFREE": "1",
-   "setA": 1,
-   "offset": 18,
-   "mRD": 1,
-   "line": 509,
-   "offsetLabel": "gasRefund",
-   "useCTX": 1,
-   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
-  },
-  {
-   "inA": "1",
-   "CONST": "15000",
-   "setA": 1,
-   "offset": 18,
-   "mWR": 1,
-   "line": 510,
-   "offsetLabel": "gasRefund",
-   "useCTX": 1,
-   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
-  },
-  {
-   "JMP": 1,
-   "offset": 854,
+   "offset": 858,
    "line": 511,
    "offsetLabel": "opSSTOREdifAB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -10016,7 +10002,38 @@
    "setA": 1,
    "offset": 18,
    "mRD": 1,
+   "line": 513,
+   "offsetLabel": "gasRefund",
+   "useCTX": 1,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "inA": "1",
+   "CONST": "15000",
+   "setA": 1,
+   "offset": 18,
+   "mWR": 1,
+   "line": 514,
+   "offsetLabel": "gasRefund",
+   "useCTX": 1,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "JMP": 1,
+   "offset": 858,
    "line": 515,
+   "offsetLabel": "opSSTOREdifAB",
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "freeInTag": {
+    "op": ""
+   },
+   "inFREE": "1",
+   "setA": 1,
+   "offset": 18,
+   "mRD": 1,
+   "line": 519,
    "offsetLabel": "gasRefund",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -10027,15 +10044,15 @@
    "setA": 1,
    "offset": 18,
    "mWR": 1,
-   "line": 516,
+   "line": 520,
    "offsetLabel": "gasRefund",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 875,
-   "line": 517,
+   "offset": 879,
+   "line": 521,
    "offsetLabel": "opSSTOREend",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -10043,7 +10060,7 @@
    "inGAS": "1",
    "CONST": "-2900",
    "setGAS": 1,
-   "line": 521,
+   "line": 525,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -10064,8 +10081,8 @@
    "inFREE": "1",
    "CONST": "-1",
    "JMPC": 1,
-   "offset": 875,
-   "line": 522,
+   "offset": 879,
+   "line": 526,
    "offsetLabel": "opSSTOREend",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -10077,7 +10094,7 @@
    "setA": 1,
    "offset": 18,
    "mRD": 1,
-   "line": 524,
+   "line": 528,
    "offsetLabel": "gasRefund",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -10088,15 +10105,15 @@
    "setA": 1,
    "offset": 18,
    "mWR": 1,
-   "line": 525,
+   "line": 529,
    "offsetLabel": "gasRefund",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 875,
-   "line": 526,
+   "offset": 879,
+   "line": 530,
    "offsetLabel": "opSSTOREend",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -10108,7 +10125,7 @@
    "setA": 1,
    "offset": 11,
    "mRD": 1,
-   "line": 529,
+   "line": 533,
    "offsetLabel": "txIsCreateContract",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -10117,8 +10134,8 @@
    "CONST": "0",
    "inA": "-1",
    "JMPC": 1,
-   "offset": 879,
-   "line": 530,
+   "offset": 883,
+   "line": 534,
    "offsetLabel": "mloadContract",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -10130,15 +10147,15 @@
    "setA": 1,
    "offset": 1,
    "mRD": 1,
-   "line": 531,
+   "line": 535,
    "offsetLabel": "txDestAddr",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 880,
-   "line": 532,
+   "offset": 884,
+   "line": 536,
    "offsetLabel": "opSSTOREsr",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -10150,7 +10167,7 @@
    "setA": 1,
    "offset": 12,
    "mRD": 1,
-   "line": 535,
+   "line": 539,
    "offsetLabel": "createContractAddress",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -10158,7 +10175,7 @@
   {
    "CONST": "3",
    "setB": 1,
-   "line": 538,
+   "line": 542,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -10168,13 +10185,13 @@
    "inFREE": "1",
    "setSR": 1,
    "sWR": 1,
-   "line": 539,
+   "line": 543,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
    "offset": 478,
-   "line": 540,
+   "line": 544,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -10182,7 +10199,7 @@
    "inSP": "1",
    "CONST": "-1",
    "setSP": 1,
-   "line": 543,
+   "line": 547,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -10200,26 +10217,26 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 544,
+   "line": 548,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inE": "1",
    "setPC": 1,
-   "line": 545,
+   "line": 549,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inGAS": "1",
    "CONST": "-8",
    "setGAS": 1,
-   "line": 546,
+   "line": 550,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
    "offset": 478,
-   "line": 547,
+   "line": 551,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -10227,7 +10244,7 @@
    "inSP": "1",
    "CONST": "-2",
    "setSP": 1,
-   "line": 550,
+   "line": 554,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -10245,14 +10262,14 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 551,
+   "line": 555,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inGAS": "1",
    "CONST": "-10",
    "setGAS": 1,
-   "line": 552,
+   "line": 556,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -10260,7 +10277,7 @@
    "CONST": "-1",
    "JMPC": 1,
    "offset": 478,
-   "line": 553,
+   "line": 557,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -10268,7 +10285,7 @@
    "inSP": "1",
    "CONST": "1",
    "setSP": 1,
-   "line": 554,
+   "line": 558,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -10286,19 +10303,19 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 555,
+   "line": 559,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inE": "1",
    "setPC": 1,
-   "line": 556,
+   "line": 560,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
    "offset": 478,
-   "line": 557,
+   "line": 561,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -10306,13 +10323,13 @@
    "inGAS": "1",
    "CONST": "-1",
    "setGAS": 1,
-   "line": 564,
+   "line": 568,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
    "offset": 478,
-   "line": 565,
+   "line": 569,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -10337,7 +10354,7 @@
    },
    "inFREE": "1",
    "setB": 1,
-   "line": 568,
+   "line": 572,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -10350,27 +10367,27 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 569,
+   "line": 573,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inPC": "1",
    "inD": "1",
    "setPC": 1,
-   "line": 570,
+   "line": 574,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inGAS": "1",
    "CONST": "-3",
    "setGAS": 1,
-   "line": 571,
+   "line": 575,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
    "offset": 478,
-   "line": 572,
+   "line": 576,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -10378,7 +10395,7 @@
    "inSP": "1",
    "offset": 9,
    "mWR": 1,
-   "line": 575,
+   "line": 579,
    "offsetLabel": "SPw",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -10391,7 +10408,7 @@
    "setSP": 1,
    "offset": 8,
    "mRD": 1,
-   "line": 576,
+   "line": 580,
    "offsetLabel": "SPr",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -10412,14 +10429,14 @@
    },
    "inFREE": "1",
    "setA": 1,
-   "line": 577,
+   "line": 581,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inSP": "1",
    "inA": "1",
    "setSP": 1,
-   "line": 578,
+   "line": 582,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -10438,7 +10455,7 @@
    },
    "inFREE": "1",
    "setC": 1,
-   "line": 579,
+   "line": 583,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -10467,8 +10484,8 @@
    },
    "inFREE": "-1",
    "JMPC": 1,
-   "offset": 916,
-   "line": 580,
+   "offset": 920,
+   "line": 584,
    "offsetLabel": "opAuxPUSHC",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -10487,7 +10504,7 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 581,
+   "line": 585,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -10498,7 +10515,7 @@
    "setSP": 1,
    "offset": 9,
    "mRD": 1,
-   "line": 582,
+   "line": 586,
    "offsetLabel": "SPw",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -10524,7 +10541,7 @@
    },
    "inFREE": "1",
    "setB": 1,
-   "line": 583,
+   "line": 587,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -10537,27 +10554,27 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 584,
+   "line": 588,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inPC": "1",
    "inD": "1",
    "setPC": 1,
-   "line": 585,
+   "line": 589,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inGAS": "1",
    "CONST": "-3",
    "setGAS": 1,
-   "line": 586,
+   "line": 590,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
    "offset": 478,
-   "line": 587,
+   "line": 591,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -10565,7 +10582,7 @@
    "CONST": "32",
    "inC": "-1",
    "setE": 1,
-   "line": 590,
+   "line": 594,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -10582,7 +10599,7 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 591,
+   "line": 595,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -10606,27 +10623,27 @@
    },
    "inFREE": "1",
    "setA": 1,
-   "line": 592,
+   "line": 596,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "CONST": "0",
    "setC": 1,
-   "line": 593,
+   "line": 597,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inPC": "1",
    "inD": "1",
    "setPC": 1,
-   "line": 594,
+   "line": 598,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inD": "1",
    "inE": "-1",
    "setD": 1,
-   "line": 595,
+   "line": 599,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -10644,7 +10661,7 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 596,
+   "line": 600,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -10668,7 +10685,7 @@
    },
    "inFREE": "1",
    "setB": 1,
-   "line": 597,
+   "line": 601,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -10678,7 +10695,7 @@
    "inFREE": "1",
    "setA": 1,
    "shr": 1,
-   "line": 598,
+   "line": 602,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -10689,7 +10706,7 @@
    "setSP": 1,
    "offset": 9,
    "mRD": 1,
-   "line": 599,
+   "line": 603,
    "offsetLabel": "SPw",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -10705,27 +10722,27 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 600,
+   "line": 604,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inGAS": "1",
    "CONST": "-3",
    "setGAS": 1,
-   "line": 601,
+   "line": 605,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
    "offset": 478,
-   "line": 602,
+   "line": 606,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "CONST": "1",
    "setD": 1,
-   "line": 605,
+   "line": 609,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -10736,7 +10753,7 @@
    "setB": 1,
    "offset": 11,
    "mRD": 1,
-   "line": 606,
+   "line": 610,
    "offsetLabel": "txIsCreateContract",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -10745,22 +10762,22 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 903,
-   "line": 607,
+   "offset": 907,
+   "line": 611,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 898,
-   "line": 608,
+   "offset": 902,
+   "line": 612,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "CONST": "2",
    "setD": 1,
-   "line": 611,
+   "line": 615,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -10771,7 +10788,7 @@
    "setB": 1,
    "offset": 11,
    "mRD": 1,
-   "line": 612,
+   "line": 616,
    "offsetLabel": "txIsCreateContract",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -10780,22 +10797,22 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 903,
-   "line": 613,
+   "offset": 907,
+   "line": 617,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 898,
-   "line": 614,
+   "offset": 902,
+   "line": 618,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "CONST": "3",
    "setD": 1,
-   "line": 617,
+   "line": 621,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -10806,7 +10823,7 @@
    "setB": 1,
    "offset": 11,
    "mRD": 1,
-   "line": 618,
+   "line": 622,
    "offsetLabel": "txIsCreateContract",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -10815,22 +10832,22 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 903,
-   "line": 619,
+   "offset": 907,
+   "line": 623,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 898,
-   "line": 620,
+   "offset": 902,
+   "line": 624,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "CONST": "4",
    "setD": 1,
-   "line": 623,
+   "line": 627,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -10841,7 +10858,7 @@
    "setB": 1,
    "offset": 11,
    "mRD": 1,
-   "line": 624,
+   "line": 628,
    "offsetLabel": "txIsCreateContract",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -10850,22 +10867,22 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 903,
-   "line": 625,
+   "offset": 907,
+   "line": 629,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 898,
-   "line": 626,
+   "offset": 902,
+   "line": 630,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "CONST": "5",
    "setD": 1,
-   "line": 629,
+   "line": 633,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -10876,7 +10893,7 @@
    "setB": 1,
    "offset": 11,
    "mRD": 1,
-   "line": 630,
+   "line": 634,
    "offsetLabel": "txIsCreateContract",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -10885,22 +10902,22 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 903,
-   "line": 631,
+   "offset": 907,
+   "line": 635,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 898,
-   "line": 632,
+   "offset": 902,
+   "line": 636,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "CONST": "6",
    "setD": 1,
-   "line": 635,
+   "line": 639,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -10911,7 +10928,7 @@
    "setB": 1,
    "offset": 11,
    "mRD": 1,
-   "line": 636,
+   "line": 640,
    "offsetLabel": "txIsCreateContract",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -10920,22 +10937,22 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 903,
-   "line": 637,
+   "offset": 907,
+   "line": 641,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 898,
-   "line": 638,
+   "offset": 902,
+   "line": 642,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "CONST": "7",
    "setD": 1,
-   "line": 641,
+   "line": 645,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -10946,7 +10963,7 @@
    "setB": 1,
    "offset": 11,
    "mRD": 1,
-   "line": 642,
+   "line": 646,
    "offsetLabel": "txIsCreateContract",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -10955,22 +10972,22 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 903,
-   "line": 643,
+   "offset": 907,
+   "line": 647,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 898,
-   "line": 644,
+   "offset": 902,
+   "line": 648,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "CONST": "8",
    "setD": 1,
-   "line": 647,
+   "line": 651,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -10981,7 +10998,7 @@
    "setB": 1,
    "offset": 11,
    "mRD": 1,
-   "line": 648,
+   "line": 652,
    "offsetLabel": "txIsCreateContract",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -10990,22 +11007,22 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 903,
-   "line": 649,
+   "offset": 907,
+   "line": 653,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 898,
-   "line": 650,
+   "offset": 902,
+   "line": 654,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "CONST": "9",
    "setD": 1,
-   "line": 653,
+   "line": 657,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -11016,7 +11033,7 @@
    "setB": 1,
    "offset": 11,
    "mRD": 1,
-   "line": 654,
+   "line": 658,
    "offsetLabel": "txIsCreateContract",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -11025,22 +11042,22 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 903,
-   "line": 655,
+   "offset": 907,
+   "line": 659,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 898,
-   "line": 656,
+   "offset": 902,
+   "line": 660,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "CONST": "10",
    "setD": 1,
-   "line": 659,
+   "line": 663,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -11051,7 +11068,7 @@
    "setB": 1,
    "offset": 11,
    "mRD": 1,
-   "line": 660,
+   "line": 664,
    "offsetLabel": "txIsCreateContract",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -11060,22 +11077,22 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 903,
-   "line": 661,
+   "offset": 907,
+   "line": 665,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 898,
-   "line": 662,
+   "offset": 902,
+   "line": 666,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "CONST": "11",
    "setD": 1,
-   "line": 665,
+   "line": 669,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -11086,7 +11103,7 @@
    "setB": 1,
    "offset": 11,
    "mRD": 1,
-   "line": 666,
+   "line": 670,
    "offsetLabel": "txIsCreateContract",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -11095,22 +11112,22 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 903,
-   "line": 667,
+   "offset": 907,
+   "line": 671,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 898,
-   "line": 668,
+   "offset": 902,
+   "line": 672,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "CONST": "12",
    "setD": 1,
-   "line": 671,
+   "line": 675,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -11121,7 +11138,7 @@
    "setB": 1,
    "offset": 11,
    "mRD": 1,
-   "line": 672,
+   "line": 676,
    "offsetLabel": "txIsCreateContract",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -11130,22 +11147,22 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 903,
-   "line": 673,
+   "offset": 907,
+   "line": 677,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 898,
-   "line": 674,
+   "offset": 902,
+   "line": 678,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "CONST": "13",
    "setD": 1,
-   "line": 677,
+   "line": 681,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -11156,7 +11173,7 @@
    "setB": 1,
    "offset": 11,
    "mRD": 1,
-   "line": 678,
+   "line": 682,
    "offsetLabel": "txIsCreateContract",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -11165,22 +11182,22 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 903,
-   "line": 679,
+   "offset": 907,
+   "line": 683,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 898,
-   "line": 680,
+   "offset": 902,
+   "line": 684,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "CONST": "14",
    "setD": 1,
-   "line": 683,
+   "line": 687,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -11191,7 +11208,7 @@
    "setB": 1,
    "offset": 11,
    "mRD": 1,
-   "line": 684,
+   "line": 688,
    "offsetLabel": "txIsCreateContract",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -11200,22 +11217,22 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 903,
-   "line": 685,
+   "offset": 907,
+   "line": 689,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 898,
-   "line": 686,
+   "offset": 902,
+   "line": 690,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "CONST": "15",
    "setD": 1,
-   "line": 689,
+   "line": 693,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -11226,7 +11243,7 @@
    "setB": 1,
    "offset": 11,
    "mRD": 1,
-   "line": 690,
+   "line": 694,
    "offsetLabel": "txIsCreateContract",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -11235,22 +11252,22 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 903,
-   "line": 691,
+   "offset": 907,
+   "line": 695,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 898,
-   "line": 692,
+   "offset": 902,
+   "line": 696,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "CONST": "16",
    "setD": 1,
-   "line": 695,
+   "line": 699,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -11261,7 +11278,7 @@
    "setB": 1,
    "offset": 11,
    "mRD": 1,
-   "line": 696,
+   "line": 700,
    "offsetLabel": "txIsCreateContract",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -11270,22 +11287,22 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 903,
-   "line": 697,
+   "offset": 907,
+   "line": 701,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 898,
-   "line": 698,
+   "offset": 902,
+   "line": 702,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "CONST": "17",
    "setD": 1,
-   "line": 701,
+   "line": 705,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -11296,7 +11313,7 @@
    "setB": 1,
    "offset": 11,
    "mRD": 1,
-   "line": 702,
+   "line": 706,
    "offsetLabel": "txIsCreateContract",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -11305,22 +11322,22 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 903,
-   "line": 703,
+   "offset": 907,
+   "line": 707,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 898,
-   "line": 704,
+   "offset": 902,
+   "line": 708,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "CONST": "18",
    "setD": 1,
-   "line": 707,
+   "line": 711,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -11331,7 +11348,7 @@
    "setB": 1,
    "offset": 11,
    "mRD": 1,
-   "line": 708,
+   "line": 712,
    "offsetLabel": "txIsCreateContract",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -11340,22 +11357,22 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 903,
-   "line": 709,
+   "offset": 907,
+   "line": 713,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 898,
-   "line": 710,
+   "offset": 902,
+   "line": 714,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "CONST": "19",
    "setD": 1,
-   "line": 713,
+   "line": 717,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -11366,7 +11383,7 @@
    "setB": 1,
    "offset": 11,
    "mRD": 1,
-   "line": 714,
+   "line": 718,
    "offsetLabel": "txIsCreateContract",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -11375,22 +11392,22 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 903,
-   "line": 715,
+   "offset": 907,
+   "line": 719,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 898,
-   "line": 716,
+   "offset": 902,
+   "line": 720,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "CONST": "20",
    "setD": 1,
-   "line": 719,
+   "line": 723,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -11401,7 +11418,7 @@
    "setB": 1,
    "offset": 11,
    "mRD": 1,
-   "line": 720,
+   "line": 724,
    "offsetLabel": "txIsCreateContract",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -11410,22 +11427,22 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 903,
-   "line": 721,
+   "offset": 907,
+   "line": 725,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 898,
-   "line": 722,
+   "offset": 902,
+   "line": 726,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "CONST": "21",
    "setD": 1,
-   "line": 725,
+   "line": 729,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -11436,7 +11453,7 @@
    "setB": 1,
    "offset": 11,
    "mRD": 1,
-   "line": 726,
+   "line": 730,
    "offsetLabel": "txIsCreateContract",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -11445,22 +11462,22 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 903,
-   "line": 727,
+   "offset": 907,
+   "line": 731,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 898,
-   "line": 728,
+   "offset": 902,
+   "line": 732,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "CONST": "22",
    "setD": 1,
-   "line": 731,
+   "line": 735,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -11471,7 +11488,7 @@
    "setB": 1,
    "offset": 11,
    "mRD": 1,
-   "line": 732,
+   "line": 736,
    "offsetLabel": "txIsCreateContract",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -11480,22 +11497,22 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 903,
-   "line": 733,
+   "offset": 907,
+   "line": 737,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 898,
-   "line": 734,
+   "offset": 902,
+   "line": 738,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "CONST": "23",
    "setD": 1,
-   "line": 737,
+   "line": 741,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -11506,7 +11523,7 @@
    "setB": 1,
    "offset": 11,
    "mRD": 1,
-   "line": 738,
+   "line": 742,
    "offsetLabel": "txIsCreateContract",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -11515,22 +11532,22 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 903,
-   "line": 739,
+   "offset": 907,
+   "line": 743,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 898,
-   "line": 740,
+   "offset": 902,
+   "line": 744,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "CONST": "24",
    "setD": 1,
-   "line": 743,
+   "line": 747,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -11541,7 +11558,7 @@
    "setB": 1,
    "offset": 11,
    "mRD": 1,
-   "line": 744,
+   "line": 748,
    "offsetLabel": "txIsCreateContract",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -11550,22 +11567,22 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 903,
-   "line": 745,
+   "offset": 907,
+   "line": 749,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 898,
-   "line": 746,
+   "offset": 902,
+   "line": 750,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "CONST": "25",
    "setD": 1,
-   "line": 749,
+   "line": 753,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -11576,7 +11593,7 @@
    "setB": 1,
    "offset": 11,
    "mRD": 1,
-   "line": 750,
+   "line": 754,
    "offsetLabel": "txIsCreateContract",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -11585,22 +11602,22 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 903,
-   "line": 751,
+   "offset": 907,
+   "line": 755,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 898,
-   "line": 752,
+   "offset": 902,
+   "line": 756,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "CONST": "26",
    "setD": 1,
-   "line": 755,
+   "line": 759,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -11611,7 +11628,7 @@
    "setB": 1,
    "offset": 11,
    "mRD": 1,
-   "line": 756,
+   "line": 760,
    "offsetLabel": "txIsCreateContract",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -11620,22 +11637,22 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 903,
-   "line": 757,
+   "offset": 907,
+   "line": 761,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 898,
-   "line": 758,
+   "offset": 902,
+   "line": 762,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "CONST": "27",
    "setD": 1,
-   "line": 761,
+   "line": 765,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -11646,7 +11663,7 @@
    "setB": 1,
    "offset": 11,
    "mRD": 1,
-   "line": 762,
+   "line": 766,
    "offsetLabel": "txIsCreateContract",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -11655,22 +11672,22 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 903,
-   "line": 763,
+   "offset": 907,
+   "line": 767,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 898,
-   "line": 764,
+   "offset": 902,
+   "line": 768,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "CONST": "28",
    "setD": 1,
-   "line": 767,
+   "line": 771,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -11681,7 +11698,7 @@
    "setB": 1,
    "offset": 11,
    "mRD": 1,
-   "line": 768,
+   "line": 772,
    "offsetLabel": "txIsCreateContract",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -11690,22 +11707,22 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 903,
-   "line": 769,
+   "offset": 907,
+   "line": 773,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 898,
-   "line": 770,
+   "offset": 902,
+   "line": 774,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "CONST": "29",
    "setD": 1,
-   "line": 773,
+   "line": 777,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -11716,7 +11733,7 @@
    "setB": 1,
    "offset": 11,
    "mRD": 1,
-   "line": 774,
+   "line": 778,
    "offsetLabel": "txIsCreateContract",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -11725,22 +11742,22 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 903,
-   "line": 775,
+   "offset": 907,
+   "line": 779,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 898,
-   "line": 776,
+   "offset": 902,
+   "line": 780,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "CONST": "30",
    "setD": 1,
-   "line": 779,
+   "line": 783,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -11751,7 +11768,7 @@
    "setB": 1,
    "offset": 11,
    "mRD": 1,
-   "line": 780,
+   "line": 784,
    "offsetLabel": "txIsCreateContract",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -11760,22 +11777,22 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 903,
-   "line": 781,
+   "offset": 907,
+   "line": 785,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 898,
-   "line": 782,
+   "offset": 902,
+   "line": 786,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "CONST": "31",
    "setD": 1,
-   "line": 785,
+   "line": 789,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -11786,7 +11803,7 @@
    "setB": 1,
    "offset": 11,
    "mRD": 1,
-   "line": 786,
+   "line": 790,
    "offsetLabel": "txIsCreateContract",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -11795,22 +11812,22 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 903,
-   "line": 787,
+   "offset": 907,
+   "line": 791,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 898,
-   "line": 788,
+   "offset": 902,
+   "line": 792,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "CONST": "32",
    "setD": 1,
-   "line": 791,
+   "line": 795,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -11821,7 +11838,7 @@
    "setB": 1,
    "offset": 11,
    "mRD": 1,
-   "line": 792,
+   "line": 796,
    "offsetLabel": "txIsCreateContract",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -11830,15 +11847,15 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 903,
-   "line": 793,
+   "offset": 907,
+   "line": 797,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 898,
-   "line": 794,
+   "offset": 902,
+   "line": 798,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -11846,7 +11863,7 @@
    "inSP": "1",
    "CONST": "-1",
    "setSP": 1,
-   "line": 797,
+   "line": 801,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -11863,7 +11880,7 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 798,
+   "line": 802,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -11876,20 +11893,20 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 799,
+   "line": 803,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inGAS": "1",
    "CONST": "-3",
    "setGAS": 1,
-   "line": 800,
+   "line": 804,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
    "offset": 478,
-   "line": 801,
+   "line": 805,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -11897,7 +11914,7 @@
    "inSP": "1",
    "CONST": "-2",
    "setSP": 1,
-   "line": 804,
+   "line": 808,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -11915,14 +11932,14 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 805,
+   "line": 809,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inSP": "1",
    "CONST": "2",
    "setSP": 1,
-   "line": 806,
+   "line": 810,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -11935,20 +11952,20 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 807,
+   "line": 811,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inGAS": "1",
    "CONST": "-3",
    "setGAS": 1,
-   "line": 808,
+   "line": 812,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
    "offset": 478,
-   "line": 809,
+   "line": 813,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -11956,7 +11973,7 @@
    "inSP": "1",
    "CONST": "-3",
    "setSP": 1,
-   "line": 812,
+   "line": 816,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -11974,14 +11991,14 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 813,
+   "line": 817,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inSP": "1",
    "CONST": "3",
    "setSP": 1,
-   "line": 814,
+   "line": 818,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -11994,20 +12011,20 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 815,
+   "line": 819,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inGAS": "1",
    "CONST": "-3",
    "setGAS": 1,
-   "line": 816,
+   "line": 820,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
    "offset": 478,
-   "line": 817,
+   "line": 821,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -12015,7 +12032,7 @@
    "inSP": "1",
    "CONST": "-4",
    "setSP": 1,
-   "line": 820,
+   "line": 824,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -12033,14 +12050,14 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 821,
+   "line": 825,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inSP": "1",
    "CONST": "4",
    "setSP": 1,
-   "line": 822,
+   "line": 826,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -12053,20 +12070,20 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 823,
+   "line": 827,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inGAS": "1",
    "CONST": "-3",
    "setGAS": 1,
-   "line": 824,
+   "line": 828,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
    "offset": 478,
-   "line": 825,
+   "line": 829,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -12074,7 +12091,7 @@
    "inSP": "1",
    "CONST": "-5",
    "setSP": 1,
-   "line": 828,
+   "line": 832,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -12092,14 +12109,14 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 829,
+   "line": 833,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inSP": "1",
    "CONST": "5",
    "setSP": 1,
-   "line": 830,
+   "line": 834,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -12112,20 +12129,20 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 831,
+   "line": 835,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inGAS": "1",
    "CONST": "-3",
    "setGAS": 1,
-   "line": 832,
+   "line": 836,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
    "offset": 478,
-   "line": 833,
+   "line": 837,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -12133,7 +12150,7 @@
    "inSP": "1",
    "CONST": "-6",
    "setSP": 1,
-   "line": 836,
+   "line": 840,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -12151,14 +12168,14 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 837,
+   "line": 841,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inSP": "1",
    "CONST": "6",
    "setSP": 1,
-   "line": 838,
+   "line": 842,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -12171,20 +12188,20 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 839,
+   "line": 843,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inGAS": "1",
    "CONST": "-3",
    "setGAS": 1,
-   "line": 840,
+   "line": 844,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
    "offset": 478,
-   "line": 841,
+   "line": 845,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -12192,7 +12209,7 @@
    "inSP": "1",
    "CONST": "-7",
    "setSP": 1,
-   "line": 844,
+   "line": 848,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -12210,14 +12227,14 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 845,
+   "line": 849,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inSP": "1",
    "CONST": "7",
    "setSP": 1,
-   "line": 846,
+   "line": 850,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -12230,20 +12247,20 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 847,
+   "line": 851,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inGAS": "1",
    "CONST": "-3",
    "setGAS": 1,
-   "line": 848,
+   "line": 852,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
    "offset": 478,
-   "line": 849,
+   "line": 853,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -12251,7 +12268,7 @@
    "inSP": "1",
    "CONST": "-8",
    "setSP": 1,
-   "line": 852,
+   "line": 856,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -12269,14 +12286,14 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 853,
+   "line": 857,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inSP": "1",
    "CONST": "8",
    "setSP": 1,
-   "line": 854,
+   "line": 858,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -12289,20 +12306,20 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 855,
+   "line": 859,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inGAS": "1",
    "CONST": "-3",
    "setGAS": 1,
-   "line": 856,
+   "line": 860,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
    "offset": 478,
-   "line": 857,
+   "line": 861,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -12310,7 +12327,7 @@
    "inSP": "1",
    "CONST": "-9",
    "setSP": 1,
-   "line": 860,
+   "line": 864,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -12328,14 +12345,14 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 861,
+   "line": 865,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inSP": "1",
    "CONST": "9",
    "setSP": 1,
-   "line": 862,
+   "line": 866,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -12348,20 +12365,20 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 863,
+   "line": 867,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inGAS": "1",
    "CONST": "-3",
    "setGAS": 1,
-   "line": 864,
+   "line": 868,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
    "offset": 478,
-   "line": 865,
+   "line": 869,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -12369,7 +12386,7 @@
    "inSP": "1",
    "CONST": "-10",
    "setSP": 1,
-   "line": 868,
+   "line": 872,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -12387,14 +12404,14 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 869,
+   "line": 873,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inSP": "1",
    "CONST": "10",
    "setSP": 1,
-   "line": 870,
+   "line": 874,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -12407,20 +12424,20 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 871,
+   "line": 875,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inGAS": "1",
    "CONST": "-3",
    "setGAS": 1,
-   "line": 872,
+   "line": 876,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
    "offset": 478,
-   "line": 873,
+   "line": 877,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -12428,7 +12445,7 @@
    "inSP": "1",
    "CONST": "-11",
    "setSP": 1,
-   "line": 876,
+   "line": 880,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -12446,14 +12463,14 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 877,
+   "line": 881,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inSP": "1",
    "CONST": "11",
    "setSP": 1,
-   "line": 878,
+   "line": 882,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -12466,20 +12483,20 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 879,
+   "line": 883,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inGAS": "1",
    "CONST": "-3",
    "setGAS": 1,
-   "line": 880,
+   "line": 884,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
    "offset": 478,
-   "line": 881,
+   "line": 885,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -12487,7 +12504,7 @@
    "inSP": "1",
    "CONST": "-12",
    "setSP": 1,
-   "line": 884,
+   "line": 888,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -12505,14 +12522,14 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 885,
+   "line": 889,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inSP": "1",
    "CONST": "12",
    "setSP": 1,
-   "line": 886,
+   "line": 890,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -12525,20 +12542,20 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 887,
+   "line": 891,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inGAS": "1",
    "CONST": "-3",
    "setGAS": 1,
-   "line": 888,
+   "line": 892,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
    "offset": 478,
-   "line": 889,
+   "line": 893,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -12546,7 +12563,7 @@
    "inSP": "1",
    "CONST": "-13",
    "setSP": 1,
-   "line": 892,
+   "line": 896,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -12564,14 +12581,14 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 893,
+   "line": 897,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inSP": "1",
    "CONST": "13",
    "setSP": 1,
-   "line": 894,
+   "line": 898,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -12584,20 +12601,20 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 895,
+   "line": 899,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inGAS": "1",
    "CONST": "-3",
    "setGAS": 1,
-   "line": 896,
+   "line": 900,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
    "offset": 478,
-   "line": 897,
+   "line": 901,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -12605,7 +12622,7 @@
    "inSP": "1",
    "CONST": "-14",
    "setSP": 1,
-   "line": 900,
+   "line": 904,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -12623,14 +12640,14 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 901,
+   "line": 905,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inSP": "1",
    "CONST": "14",
    "setSP": 1,
-   "line": 902,
+   "line": 906,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -12643,20 +12660,20 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 903,
+   "line": 907,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inGAS": "1",
    "CONST": "-3",
    "setGAS": 1,
-   "line": 904,
+   "line": 908,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
    "offset": 478,
-   "line": 905,
+   "line": 909,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -12664,7 +12681,7 @@
    "inSP": "1",
    "CONST": "-15",
    "setSP": 1,
-   "line": 908,
+   "line": 912,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -12682,14 +12699,14 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 909,
+   "line": 913,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inSP": "1",
    "CONST": "15",
    "setSP": 1,
-   "line": 910,
+   "line": 914,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -12702,20 +12719,20 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 911,
+   "line": 915,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inGAS": "1",
    "CONST": "-3",
    "setGAS": 1,
-   "line": 912,
+   "line": 916,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
    "offset": 478,
-   "line": 913,
+   "line": 917,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -12723,7 +12740,7 @@
    "inSP": "1",
    "CONST": "-16",
    "setSP": 1,
-   "line": 916,
+   "line": 920,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -12741,14 +12758,14 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 917,
+   "line": 921,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inSP": "1",
    "CONST": "16",
    "setSP": 1,
-   "line": 918,
+   "line": 922,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -12761,20 +12778,20 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 919,
+   "line": 923,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inGAS": "1",
    "CONST": "-3",
    "setGAS": 1,
-   "line": 920,
+   "line": 924,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
    "offset": 478,
-   "line": 921,
+   "line": 925,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -12782,7 +12799,7 @@
    "inSP": "1",
    "CONST": "-1",
    "setSP": 1,
-   "line": 924,
+   "line": 928,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -12800,7 +12817,7 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 925,
+   "line": 929,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -12818,7 +12835,7 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 926,
+   "line": 930,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -12831,7 +12848,7 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 927,
+   "line": 931,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -12844,20 +12861,20 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 928,
+   "line": 932,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inGAS": "1",
    "CONST": "-3",
    "setGAS": 1,
-   "line": 929,
+   "line": 933,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
    "offset": 478,
-   "line": 930,
+   "line": 934,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -12865,7 +12882,7 @@
    "inSP": "1",
    "CONST": "-1",
    "setSP": 1,
-   "line": 933,
+   "line": 937,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -12883,14 +12900,14 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 934,
+   "line": 938,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inSP": "1",
    "CONST": "-2",
    "setSP": 1,
-   "line": 935,
+   "line": 939,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -12908,7 +12925,7 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 936,
+   "line": 940,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -12922,14 +12939,14 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 937,
+   "line": 941,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inSP": "1",
    "CONST": "2",
    "setSP": 1,
-   "line": 938,
+   "line": 942,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -12942,20 +12959,20 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 939,
+   "line": 943,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inGAS": "1",
    "CONST": "-3",
    "setGAS": 1,
-   "line": 940,
+   "line": 944,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
    "offset": 478,
-   "line": 941,
+   "line": 945,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -12963,7 +12980,7 @@
    "inSP": "1",
    "CONST": "-1",
    "setSP": 1,
-   "line": 944,
+   "line": 948,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -12981,14 +12998,14 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 945,
+   "line": 949,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inSP": "1",
    "CONST": "-3",
    "setSP": 1,
-   "line": 946,
+   "line": 950,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -13006,7 +13023,7 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 947,
+   "line": 951,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -13020,14 +13037,14 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 948,
+   "line": 952,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inSP": "1",
    "CONST": "3",
    "setSP": 1,
-   "line": 949,
+   "line": 953,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -13040,20 +13057,20 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 950,
+   "line": 954,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inGAS": "1",
    "CONST": "-3",
    "setGAS": 1,
-   "line": 951,
+   "line": 955,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
    "offset": 478,
-   "line": 952,
+   "line": 956,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -13061,7 +13078,7 @@
    "inSP": "1",
    "CONST": "-1",
    "setSP": 1,
-   "line": 955,
+   "line": 959,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -13079,14 +13096,14 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 956,
+   "line": 960,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inSP": "1",
    "CONST": "-4",
    "setSP": 1,
-   "line": 957,
+   "line": 961,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -13104,7 +13121,7 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 958,
+   "line": 962,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -13118,14 +13135,14 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 959,
+   "line": 963,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inSP": "1",
    "CONST": "4",
    "setSP": 1,
-   "line": 960,
+   "line": 964,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -13138,20 +13155,20 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 961,
+   "line": 965,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inGAS": "1",
    "CONST": "-3",
    "setGAS": 1,
-   "line": 962,
+   "line": 966,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
    "offset": 478,
-   "line": 963,
+   "line": 967,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -13159,7 +13176,7 @@
    "inSP": "1",
    "CONST": "-1",
    "setSP": 1,
-   "line": 966,
+   "line": 970,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -13177,14 +13194,14 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 967,
+   "line": 971,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inSP": "1",
    "CONST": "-5",
    "setSP": 1,
-   "line": 968,
+   "line": 972,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -13202,7 +13219,7 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 969,
+   "line": 973,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -13216,14 +13233,14 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 970,
+   "line": 974,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inSP": "1",
    "CONST": "5",
    "setSP": 1,
-   "line": 971,
+   "line": 975,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -13236,20 +13253,20 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 972,
+   "line": 976,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inGAS": "1",
    "CONST": "-3",
    "setGAS": 1,
-   "line": 973,
+   "line": 977,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
    "offset": 478,
-   "line": 974,
+   "line": 978,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -13257,7 +13274,7 @@
    "inSP": "1",
    "CONST": "-1",
    "setSP": 1,
-   "line": 977,
+   "line": 981,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -13275,14 +13292,14 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 978,
+   "line": 982,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inSP": "1",
    "CONST": "-6",
    "setSP": 1,
-   "line": 979,
+   "line": 983,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -13300,7 +13317,7 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 980,
+   "line": 984,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -13314,14 +13331,14 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 981,
+   "line": 985,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inSP": "1",
    "CONST": "6",
    "setSP": 1,
-   "line": 982,
+   "line": 986,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -13334,20 +13351,20 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 983,
+   "line": 987,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inGAS": "1",
    "CONST": "-3",
    "setGAS": 1,
-   "line": 984,
+   "line": 988,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
    "offset": 478,
-   "line": 985,
+   "line": 989,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -13355,7 +13372,7 @@
    "inSP": "1",
    "CONST": "-1",
    "setSP": 1,
-   "line": 988,
+   "line": 992,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -13373,14 +13390,14 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 989,
+   "line": 993,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inSP": "1",
    "CONST": "-7",
    "setSP": 1,
-   "line": 990,
+   "line": 994,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -13398,7 +13415,7 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 991,
+   "line": 995,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -13412,14 +13429,14 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 992,
+   "line": 996,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inSP": "1",
    "CONST": "7",
    "setSP": 1,
-   "line": 993,
+   "line": 997,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -13432,20 +13449,20 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 994,
+   "line": 998,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inGAS": "1",
    "CONST": "-3",
    "setGAS": 1,
-   "line": 995,
+   "line": 999,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
    "offset": 478,
-   "line": 996,
+   "line": 1000,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -13453,7 +13470,7 @@
    "inSP": "1",
    "CONST": "-1",
    "setSP": 1,
-   "line": 999,
+   "line": 1003,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -13471,14 +13488,14 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 1000,
+   "line": 1004,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inSP": "1",
    "CONST": "-8",
    "setSP": 1,
-   "line": 1001,
+   "line": 1005,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -13496,7 +13513,7 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 1002,
+   "line": 1006,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -13510,14 +13527,14 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 1003,
+   "line": 1007,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inSP": "1",
    "CONST": "8",
    "setSP": 1,
-   "line": 1004,
+   "line": 1008,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -13530,20 +13547,20 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 1005,
+   "line": 1009,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inGAS": "1",
    "CONST": "-3",
    "setGAS": 1,
-   "line": 1006,
+   "line": 1010,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
    "offset": 478,
-   "line": 1007,
+   "line": 1011,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -13551,7 +13568,7 @@
    "inSP": "1",
    "CONST": "-1",
    "setSP": 1,
-   "line": 1010,
+   "line": 1014,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -13569,14 +13586,14 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 1011,
+   "line": 1015,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inSP": "1",
    "CONST": "-9",
    "setSP": 1,
-   "line": 1012,
+   "line": 1016,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -13594,7 +13611,7 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 1013,
+   "line": 1017,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -13608,14 +13625,14 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 1014,
+   "line": 1018,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inSP": "1",
    "CONST": "9",
    "setSP": 1,
-   "line": 1015,
+   "line": 1019,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -13628,20 +13645,20 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 1016,
+   "line": 1020,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inGAS": "1",
    "CONST": "-3",
    "setGAS": 1,
-   "line": 1017,
+   "line": 1021,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
    "offset": 478,
-   "line": 1018,
+   "line": 1022,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -13649,7 +13666,7 @@
    "inSP": "1",
    "CONST": "-1",
    "setSP": 1,
-   "line": 1021,
+   "line": 1025,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -13667,14 +13684,14 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 1022,
+   "line": 1026,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inSP": "1",
    "CONST": "-10",
    "setSP": 1,
-   "line": 1023,
+   "line": 1027,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -13692,7 +13709,7 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 1024,
+   "line": 1028,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -13706,14 +13723,14 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 1025,
+   "line": 1029,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inSP": "1",
    "CONST": "10",
    "setSP": 1,
-   "line": 1026,
+   "line": 1030,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -13726,20 +13743,20 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 1027,
+   "line": 1031,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inGAS": "1",
    "CONST": "-3",
    "setGAS": 1,
-   "line": 1028,
+   "line": 1032,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
    "offset": 478,
-   "line": 1029,
+   "line": 1033,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -13747,7 +13764,7 @@
    "inSP": "1",
    "CONST": "-1",
    "setSP": 1,
-   "line": 1032,
+   "line": 1036,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -13765,14 +13782,14 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 1033,
+   "line": 1037,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inSP": "1",
    "CONST": "-11",
    "setSP": 1,
-   "line": 1034,
+   "line": 1038,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -13790,7 +13807,7 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 1035,
+   "line": 1039,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -13804,14 +13821,14 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 1036,
+   "line": 1040,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inSP": "1",
    "CONST": "11",
    "setSP": 1,
-   "line": 1037,
+   "line": 1041,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -13824,20 +13841,20 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 1038,
+   "line": 1042,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inGAS": "1",
    "CONST": "-3",
    "setGAS": 1,
-   "line": 1039,
+   "line": 1043,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
    "offset": 478,
-   "line": 1040,
+   "line": 1044,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -13845,7 +13862,7 @@
    "inSP": "1",
    "CONST": "-1",
    "setSP": 1,
-   "line": 1043,
+   "line": 1047,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -13863,14 +13880,14 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 1044,
+   "line": 1048,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inSP": "1",
    "CONST": "-12",
    "setSP": 1,
-   "line": 1045,
+   "line": 1049,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -13888,7 +13905,7 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 1046,
+   "line": 1050,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -13902,14 +13919,14 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 1047,
+   "line": 1051,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inSP": "1",
    "CONST": "12",
    "setSP": 1,
-   "line": 1048,
+   "line": 1052,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -13922,20 +13939,20 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 1049,
+   "line": 1053,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inGAS": "1",
    "CONST": "-3",
    "setGAS": 1,
-   "line": 1050,
+   "line": 1054,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
    "offset": 478,
-   "line": 1051,
+   "line": 1055,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -13943,7 +13960,7 @@
    "inSP": "1",
    "CONST": "-1",
    "setSP": 1,
-   "line": 1054,
+   "line": 1058,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -13961,14 +13978,14 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 1055,
+   "line": 1059,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inSP": "1",
    "CONST": "-13",
    "setSP": 1,
-   "line": 1056,
+   "line": 1060,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -13986,7 +14003,7 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 1057,
+   "line": 1061,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -14000,14 +14017,14 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 1058,
+   "line": 1062,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inSP": "1",
    "CONST": "13",
    "setSP": 1,
-   "line": 1059,
+   "line": 1063,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -14020,20 +14037,20 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 1060,
+   "line": 1064,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inGAS": "1",
    "CONST": "-3",
    "setGAS": 1,
-   "line": 1061,
+   "line": 1065,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
    "offset": 478,
-   "line": 1062,
+   "line": 1066,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -14041,7 +14058,7 @@
    "inSP": "1",
    "CONST": "-1",
    "setSP": 1,
-   "line": 1065,
+   "line": 1069,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -14059,14 +14076,14 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 1066,
+   "line": 1070,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inSP": "1",
    "CONST": "-14",
    "setSP": 1,
-   "line": 1067,
+   "line": 1071,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -14084,7 +14101,7 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 1068,
+   "line": 1072,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -14098,14 +14115,14 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 1069,
+   "line": 1073,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inSP": "1",
    "CONST": "14",
    "setSP": 1,
-   "line": 1070,
+   "line": 1074,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -14118,20 +14135,20 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 1071,
+   "line": 1075,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inGAS": "1",
    "CONST": "-3",
    "setGAS": 1,
-   "line": 1072,
+   "line": 1076,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
    "offset": 478,
-   "line": 1073,
+   "line": 1077,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -14139,7 +14156,7 @@
    "inSP": "1",
    "CONST": "-1",
    "setSP": 1,
-   "line": 1076,
+   "line": 1080,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -14157,14 +14174,14 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 1077,
+   "line": 1081,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inSP": "1",
    "CONST": "-15",
    "setSP": 1,
-   "line": 1078,
+   "line": 1082,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -14182,7 +14199,7 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 1079,
+   "line": 1083,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -14196,14 +14213,14 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 1080,
+   "line": 1084,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inSP": "1",
    "CONST": "15",
    "setSP": 1,
-   "line": 1081,
+   "line": 1085,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -14216,20 +14233,20 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 1082,
+   "line": 1086,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inGAS": "1",
    "CONST": "-3",
    "setGAS": 1,
-   "line": 1083,
+   "line": 1087,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
    "offset": 478,
-   "line": 1084,
+   "line": 1088,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -14237,7 +14254,7 @@
    "inSP": "1",
    "CONST": "-1",
    "setSP": 1,
-   "line": 1087,
+   "line": 1091,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -14255,14 +14272,14 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 1088,
+   "line": 1092,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inSP": "1",
    "CONST": "-16",
    "setSP": 1,
-   "line": 1089,
+   "line": 1093,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -14280,7 +14297,7 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 1090,
+   "line": 1094,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -14294,14 +14311,14 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 1091,
+   "line": 1095,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inSP": "1",
    "CONST": "16",
    "setSP": 1,
-   "line": 1092,
+   "line": 1096,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -14314,20 +14331,20 @@
    "offset": 0,
    "useCTX": 1,
    "mWR": 1,
-   "line": 1093,
+   "line": 1097,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "inGAS": "1",
    "CONST": "-3",
    "setGAS": 1,
-   "line": 1094,
+   "line": 1098,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
    "offset": 478,
-   "line": 1095,
+   "line": 1099,
    "offsetLabel": "readCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
@@ -14335,7 +14352,7 @@
    "inSP": "1",
    "CONST": "-1",
    "setSP": 1,
-   "line": 1107,
+   "line": 1111,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -14353,7 +14370,7 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 1108,
+   "line": 1112,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -14371,7 +14388,7 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 1109,
+   "line": 1113,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -14389,7 +14406,7 @@
    "offset": 0,
    "useCTX": 1,
    "mRD": 1,
-   "line": 1110,
+   "line": 1114,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -14400,7 +14417,7 @@
    "setD": 1,
    "offset": 11,
    "mRD": 1,
-   "line": 1111,
+   "line": 1115,
    "offsetLabel": "txIsCreateContract",
    "useCTX": 1,
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -14409,23 +14426,9 @@
    "CONST": "0",
    "inD": "-1",
    "JMPC": 1,
-   "offset": 1301,
-   "line": 1112,
-   "offsetLabel": "opRETURNdeploy",
-   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
-  },
-  {
-   "JMP": 1,
-   "offset": 481,
+   "offset": 1305,
    "line": 1116,
-   "offsetLabel": "endCode",
-   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
-  },
-  {
-   "inGAS": "1",
-   "inB": "-200",
-   "setGAS": 1,
-   "line": 1119,
+   "offsetLabel": "opRETURNdeploy",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
@@ -14436,9 +14439,23 @@
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
+   "inGAS": "1",
+   "inB": "-200",
+   "setGAS": 1,
+   "line": 1123,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "JMP": 1,
+   "offset": 481,
+   "line": 1124,
+   "offsetLabel": "endCode",
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
    "JMP": 1,
    "offset": 559,
-   "line": 1127,
+   "line": 1131,
    "offsetLabel": "invalidTx",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   }
@@ -14531,116 +14548,116 @@
   "opEQ": 650,
   "opISZERO": 656,
   "opAND": 661,
-  "opOR": 666,
-  "opXOR": 671,
-  "opNOT": 676,
-  "opBYTE": 681,
-  "opSHR": 688,
-  "opSHL": 696,
-  "opCALLVALUE": 704,
-  "opCALLDATALOAD": 708,
-  "opCALLDATALOAD2": 720,
-  "opCALLDATASIZE": 732,
-  "opCODESIZE": 736,
-  "opCODECOPY": 740,
-  "opCODECOPY1": 749,
-  "opCODECOPYfinal": 767,
-  "opCODECOPYxor": 783,
-  "opCODECOPYend": 784,
-  "opGASPRICE": 789,
-  "opGASLIMIT": 793,
-  "opCHAINID": 797,
-  "opPOP": 801,
-  "opMLOAD": 804,
-  "opMSTORE": 813,
-  "saveMemLength": 822,
-  "opSSTORE": 828,
-  "deploymentSSTORE": 835,
-  "opSSTOREinit": 836,
-  "opSSTOREdif": 847,
-  "opSSTOREdifA": 851,
-  "opSSTOREdifAA": 852,
-  "opSSTOREdifAB": 854,
-  "opSSTOREdifA1": 859,
-  "opSSTOREdifA12": 863,
-  "opSSTOREdifA2": 867,
-  "opSSTOREdifB": 870,
-  "opSSTOREend": 875,
-  "mloadContract": 879,
-  "opSSTOREsr": 880,
-  "opJUMP": 883,
-  "opJUMPI": 888,
-  "opJUMPDEST": 896,
-  "opAuxPUSHA": 898,
-  "opAuxPUSHB": 903,
-  "opAuxPUSHC": 916,
-  "opPUSH1": 929,
-  "opPUSH2": 933,
-  "opPUSH3": 937,
-  "opPUSH4": 941,
-  "opPUSH5": 945,
-  "opPUSH6": 949,
-  "opPUSH7": 953,
-  "opPUSH8": 957,
-  "opPUSH9": 961,
-  "opPUSH10": 965,
-  "opPUSH11": 969,
-  "opPUSH12": 973,
-  "opPUSH13": 977,
-  "opPUSH14": 981,
-  "opPUSH15": 985,
-  "opPUSH16": 989,
-  "opPUSH17": 993,
-  "opPUSH18": 997,
-  "opPUSH19": 1001,
-  "opPUSH20": 1005,
-  "opPUSH21": 1009,
-  "opPUSH22": 1013,
-  "opPUSH23": 1017,
-  "opPUSH24": 1021,
-  "opPUSH25": 1025,
-  "opPUSH26": 1029,
-  "opPUSH27": 1033,
-  "opPUSH28": 1037,
-  "opPUSH29": 1041,
-  "opPUSH30": 1045,
-  "opPUSH31": 1049,
-  "opPUSH32": 1053,
-  "opDUP1": 1057,
-  "opDUP2": 1062,
-  "opDUP3": 1068,
-  "opDUP4": 1074,
-  "opDUP5": 1080,
-  "opDUP6": 1086,
-  "opDUP7": 1092,
-  "opDUP8": 1098,
-  "opDUP9": 1104,
-  "opDUP10": 1110,
-  "opDUP11": 1116,
-  "opDUP12": 1122,
-  "opDUP13": 1128,
-  "opDUP14": 1134,
-  "opDUP15": 1140,
-  "opDUP16": 1146,
-  "opSWAP1": 1152,
-  "opSWAP2": 1159,
-  "opSWAP3": 1168,
-  "opSWAP4": 1177,
-  "opSWAP5": 1186,
-  "opSWAP6": 1195,
-  "opSWAP7": 1204,
-  "opSWAP8": 1213,
-  "opSWAP9": 1222,
-  "opSWAP10": 1231,
-  "opSWAP11": 1240,
-  "opSWAP12": 1249,
-  "opSWAP13": 1258,
-  "opSWAP14": 1267,
-  "opSWAP15": 1276,
-  "opSWAP16": 1285,
-  "opRETURN": 1294,
-  "opRETURNdeploy": 1301,
-  "opREVERT": 1303,
-  "opINVALID": 1304
+  "opOR": 667,
+  "opXOR": 673,
+  "opNOT": 679,
+  "opBYTE": 684,
+  "opSHR": 692,
+  "opSHL": 700,
+  "opCALLVALUE": 708,
+  "opCALLDATALOAD": 712,
+  "opCALLDATALOAD2": 724,
+  "opCALLDATASIZE": 736,
+  "opCODESIZE": 740,
+  "opCODECOPY": 744,
+  "opCODECOPY1": 753,
+  "opCODECOPYfinal": 771,
+  "opCODECOPYxor": 787,
+  "opCODECOPYend": 788,
+  "opGASPRICE": 793,
+  "opGASLIMIT": 797,
+  "opCHAINID": 801,
+  "opPOP": 805,
+  "opMLOAD": 808,
+  "opMSTORE": 817,
+  "saveMemLength": 826,
+  "opSSTORE": 832,
+  "deploymentSSTORE": 839,
+  "opSSTOREinit": 840,
+  "opSSTOREdif": 851,
+  "opSSTOREdifA": 855,
+  "opSSTOREdifAA": 856,
+  "opSSTOREdifAB": 858,
+  "opSSTOREdifA1": 863,
+  "opSSTOREdifA12": 867,
+  "opSSTOREdifA2": 871,
+  "opSSTOREdifB": 874,
+  "opSSTOREend": 879,
+  "mloadContract": 883,
+  "opSSTOREsr": 884,
+  "opJUMP": 887,
+  "opJUMPI": 892,
+  "opJUMPDEST": 900,
+  "opAuxPUSHA": 902,
+  "opAuxPUSHB": 907,
+  "opAuxPUSHC": 920,
+  "opPUSH1": 933,
+  "opPUSH2": 937,
+  "opPUSH3": 941,
+  "opPUSH4": 945,
+  "opPUSH5": 949,
+  "opPUSH6": 953,
+  "opPUSH7": 957,
+  "opPUSH8": 961,
+  "opPUSH9": 965,
+  "opPUSH10": 969,
+  "opPUSH11": 973,
+  "opPUSH12": 977,
+  "opPUSH13": 981,
+  "opPUSH14": 985,
+  "opPUSH15": 989,
+  "opPUSH16": 993,
+  "opPUSH17": 997,
+  "opPUSH18": 1001,
+  "opPUSH19": 1005,
+  "opPUSH20": 1009,
+  "opPUSH21": 1013,
+  "opPUSH22": 1017,
+  "opPUSH23": 1021,
+  "opPUSH24": 1025,
+  "opPUSH25": 1029,
+  "opPUSH26": 1033,
+  "opPUSH27": 1037,
+  "opPUSH28": 1041,
+  "opPUSH29": 1045,
+  "opPUSH30": 1049,
+  "opPUSH31": 1053,
+  "opPUSH32": 1057,
+  "opDUP1": 1061,
+  "opDUP2": 1066,
+  "opDUP3": 1072,
+  "opDUP4": 1078,
+  "opDUP5": 1084,
+  "opDUP6": 1090,
+  "opDUP7": 1096,
+  "opDUP8": 1102,
+  "opDUP9": 1108,
+  "opDUP10": 1114,
+  "opDUP11": 1120,
+  "opDUP12": 1126,
+  "opDUP13": 1132,
+  "opDUP14": 1138,
+  "opDUP15": 1144,
+  "opDUP16": 1150,
+  "opSWAP1": 1156,
+  "opSWAP2": 1163,
+  "opSWAP3": 1172,
+  "opSWAP4": 1181,
+  "opSWAP5": 1190,
+  "opSWAP6": 1199,
+  "opSWAP7": 1208,
+  "opSWAP8": 1217,
+  "opSWAP9": 1226,
+  "opSWAP10": 1235,
+  "opSWAP11": 1244,
+  "opSWAP12": 1253,
+  "opSWAP13": 1262,
+  "opSWAP14": 1271,
+  "opSWAP15": 1280,
+  "opSWAP16": 1289,
+  "opRETURN": 1298,
+  "opRETURNdeploy": 1305,
+  "opREVERT": 1307,
+  "opINVALID": 1308
  }
 }

--- a/main/opcodes.zkasm
+++ b/main/opcodes.zkasm
@@ -188,6 +188,7 @@ opAND:
     SP - 1 => SP
     $ => A                  :MLOAD(SP--)
     $ => B                  :MLOAD(SP)
+    GAS-3 => GAS
     ${bitwise_and(A, B)}    :MSTORE(SP++)
                             :JMP(readCode)
 
@@ -195,6 +196,7 @@ opOR:
     SP - 1 => SP
     $ => A                  :MLOAD(SP--)
     $ => B                  :MLOAD(SP)
+    GAS-3 => GAS
     ${bitwise_or(A, B)}     :MSTORE(SP++)
                             :JMP(readCode)
 
@@ -202,22 +204,24 @@ opXOR:
     SP - 1 => SP
     $ => A                  :MLOAD(SP--)
     $ => B                  :MLOAD(SP)
+    GAS-3 => GAS
     ${bitwise_xor(A, B)}    :MSTORE(SP++)
                             :JMP(readCode)
 
 opNOT:
     SP - 1 => SP
-    $ => A                  :MLOAD(SP--)
-    $ => B                  :MLOAD(SP)
-    ${bitwise_not(A)}    :MSTORE(SP++)
+    $ => A                  :MLOAD(SP)
+    GAS-3 => GAS
+    ${bitwise_not(A)}       :MSTORE(SP++)
                             :JMP(readCode)
 
 opBYTE:
     SP - 1 => SP
-    $ => A                  :MLOAD(SP--)
-    $ => B                  :MLOAD(SP)
+    $ => B                  :MLOAD(SP--)
+    $ => A                  :MLOAD(SP)
     31 - B => D
     $ => B                  :SHR
+    GAS-3 => GAS
     ${bitwise_and(B, 255)}  :MSTORE(SP++)
                             :JMP(readCode)
 


### PR DESCRIPTION
- fix gas for `AND`, `OR`, `XOR`, `NOT`
- fix opcodes `NOT`, `BYTE`