### PR TITLE
add SELFDESTRUCT

### DIFF
--- a/build/rom.json
+++ b/build/rom.json
@@ -9012,6 +9012,251 @@
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/utils.zkasm"
   },
   {
+   "inA": "1",
+   "offset": 31,
+   "mWR": 1,
+   "line": 297,
+   "offsetLabel": "tmpVarA",
+   "useCTX": 0,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/utils.zkasm"
+  },
+  {
+   "inB": "1",
+   "offset": 32,
+   "mWR": 1,
+   "line": 298,
+   "offsetLabel": "tmpVarB",
+   "useCTX": 0,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/utils.zkasm"
+  },
+  {
+   "inC": "1",
+   "offset": 33,
+   "mWR": 1,
+   "line": 299,
+   "offsetLabel": "tmpVarC",
+   "useCTX": 0,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/utils.zkasm"
+  },
+  {
+   "inD": "1",
+   "offset": 34,
+   "mWR": 1,
+   "line": 300,
+   "offsetLabel": "tmpVarD",
+   "useCTX": 0,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/utils.zkasm"
+  },
+  {
+   "inE": "1",
+   "setA": 1,
+   "line": 302,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/utils.zkasm"
+  },
+  {
+   "CONST": "0",
+   "setB": 1,
+   "setC": 1,
+   "line": 303,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/utils.zkasm"
+  },
+  {
+   "freeInTag": {
+    "op": ""
+   },
+   "inFREE": "1",
+   "setD": 1,
+   "sRD": 1,
+   "line": 304,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/utils.zkasm"
+  },
+  {
+   "freeInTag": {
+    "op": "functionCall",
+    "funcName": "comp_eq",
+    "params": [
+     {
+      "op": "getReg",
+      "regName": "D"
+     },
+     {
+      "op": "number",
+      "num": "0"
+     }
+    ]
+   },
+   "inFREE": "1",
+   "CONST": "-1",
+   "JMPC": 1,
+   "offset": 819,
+   "line": 305,
+   "offsetLabel": "ISEMPTYSet0",
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/utils.zkasm"
+  },
+  {
+   "CONST": "1",
+   "setB": 1,
+   "line": 308,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/utils.zkasm"
+  },
+  {
+   "freeInTag": {
+    "op": ""
+   },
+   "inFREE": "1",
+   "setD": 1,
+   "sRD": 1,
+   "line": 309,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/utils.zkasm"
+  },
+  {
+   "freeInTag": {
+    "op": "functionCall",
+    "funcName": "comp_eq",
+    "params": [
+     {
+      "op": "getReg",
+      "regName": "D"
+     },
+     {
+      "op": "number",
+      "num": "0"
+     }
+    ]
+   },
+   "inFREE": "1",
+   "CONST": "-1",
+   "JMPC": 1,
+   "offset": 819,
+   "line": 310,
+   "offsetLabel": "ISEMPTYSet0",
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/utils.zkasm"
+  },
+  {
+   "CONST": "2",
+   "setB": 1,
+   "line": 313,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/utils.zkasm"
+  },
+  {
+   "freeInTag": {
+    "op": ""
+   },
+   "inFREE": "1",
+   "setD": 1,
+   "sRD": 1,
+   "line": 314,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/utils.zkasm"
+  },
+  {
+   "freeInTag": {
+    "op": "functionCall",
+    "funcName": "comp_eq",
+    "params": [
+     {
+      "op": "getReg",
+      "regName": "D"
+     },
+     {
+      "op": "number",
+      "num": "0"
+     }
+    ]
+   },
+   "inFREE": "1",
+   "CONST": "-1",
+   "JMPC": 1,
+   "offset": 819,
+   "line": 315,
+   "offsetLabel": "ISEMPTYSet0",
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/utils.zkasm"
+  },
+  {
+   "CONST": "1",
+   "setE": 1,
+   "line": 318,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/utils.zkasm"
+  },
+  {
+   "JMP": 1,
+   "offset": 821,
+   "line": 319,
+   "offsetLabel": "ISEMPTYEnd",
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/utils.zkasm"
+  },
+  {
+   "CONST": "0",
+   "setE": 1,
+   "line": 322,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/utils.zkasm"
+  },
+  {
+   "JMP": 1,
+   "offset": 821,
+   "line": 323,
+   "offsetLabel": "ISEMPTYEnd",
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/utils.zkasm"
+  },
+  {
+   "freeInTag": {
+    "op": ""
+   },
+   "inFREE": "1",
+   "setA": 1,
+   "offset": 31,
+   "mRD": 1,
+   "line": 326,
+   "offsetLabel": "tmpVarA",
+   "useCTX": 0,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/utils.zkasm"
+  },
+  {
+   "freeInTag": {
+    "op": ""
+   },
+   "inFREE": "1",
+   "setB": 1,
+   "offset": 32,
+   "mRD": 1,
+   "line": 327,
+   "offsetLabel": "tmpVarB",
+   "useCTX": 0,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/utils.zkasm"
+  },
+  {
+   "freeInTag": {
+    "op": ""
+   },
+   "inFREE": "1",
+   "setC": 1,
+   "offset": 33,
+   "mRD": 1,
+   "line": 328,
+   "offsetLabel": "tmpVarC",
+   "useCTX": 0,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/utils.zkasm"
+  },
+  {
+   "freeInTag": {
+    "op": ""
+   },
+   "inFREE": "1",
+   "setD": 1,
+   "offset": 34,
+   "mRD": 1,
+   "line": 329,
+   "offsetLabel": "tmpVarD",
+   "useCTX": 0,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/utils.zkasm"
+  },
+  {
+   "JMP": 1,
+   "ind": 1,
+   "offset": 0,
+   "line": 330,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/utils.zkasm"
+  },
+  {
    "JMP": 1,
    "offset": 517,
    "line": 4,
@@ -9960,7 +10205,7 @@
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "882",
+   "CONST": "905",
    "setRR": 1,
    "JMP": 1,
    "offset": 665,
@@ -10971,7 +11216,7 @@
    "CONST": "0",
    "inA": "-1",
    "JMPC": 1,
-   "offset": 962,
+   "offset": 985,
    "line": 262,
    "offsetLabel": "opADDRESSdeploy",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -10991,7 +11236,7 @@
   },
   {
    "JMP": 1,
-   "offset": 963,
+   "offset": 986,
    "line": 264,
    "offsetLabel": "opADDRESSend",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -11313,7 +11558,7 @@
    "CONST": "0",
    "inA": "-1",
    "JMPC": 1,
-   "offset": 998,
+   "offset": 1021,
    "line": 307,
    "offsetLabel": "opCALLDATALOAD2",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -11664,7 +11909,7 @@
   },
   {
    "JMP": 1,
-   "offset": 1023,
+   "offset": 1046,
    "line": 345,
    "offsetLabel": "opCALLDATACOPYinit",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -11673,7 +11918,7 @@
    "inC": "1",
    "CONST": "-1",
    "JMPC": 1,
-   "offset": 1065,
+   "offset": 1088,
    "line": 348,
    "offsetLabel": "opCALLDATACOPYend",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -11682,7 +11927,7 @@
    "inC": "1",
    "CONST": "-32",
    "JMPC": 1,
-   "offset": 1041,
+   "offset": 1064,
    "line": 349,
    "offsetLabel": "opCALLDATACOPYfinal",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -11820,7 +12065,7 @@
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1035",
+   "CONST": "1058",
    "setRR": 1,
    "JMP": 1,
    "offset": 676,
@@ -11889,7 +12134,7 @@
   },
   {
    "JMP": 1,
-   "offset": 1023,
+   "offset": 1046,
    "line": 365,
    "offsetLabel": "opCALLDATACOPYinit",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -12023,7 +12268,7 @@
   {
    "inD": "1",
    "JMPC": 1,
-   "offset": 1060,
+   "offset": 1083,
    "line": 376,
    "offsetLabel": "opCALLDATACOPYxor",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -12103,7 +12348,7 @@
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1059",
+   "CONST": "1082",
    "setRR": 1,
    "JMP": 1,
    "offset": 710,
@@ -12113,7 +12358,7 @@
   },
   {
    "JMP": 1,
-   "offset": 1065,
+   "offset": 1088,
    "line": 386,
    "offsetLabel": "opCALLDATACOPYend",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -12155,7 +12400,7 @@
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1065",
+   "CONST": "1088",
    "setRR": 1,
    "JMP": 1,
    "offset": 710,
@@ -12206,7 +12451,7 @@
    "inB": "1",
    "inE": "-1",
    "JMPC": 1,
-   "offset": 1280,
+   "offset": 1303,
    "line": 399,
    "offsetLabel": "saveMemLength",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -12235,7 +12480,7 @@
    "CONST": "0",
    "inA": "-1",
    "JMPC": 1,
-   "offset": 1080,
+   "offset": 1103,
    "line": 405,
    "offsetLabel": "oopCODESIZEdep",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -12375,7 +12620,7 @@
    "CONST": "0",
    "inA": "-1",
    "JMPC": 1,
-   "offset": 1014,
+   "offset": 1037,
    "line": 423,
    "offsetLabel": "opCALLDATACOPY",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -12535,7 +12780,7 @@
    "inC": "1",
    "CONST": "-1",
    "JMPC": 1,
-   "offset": 1110,
+   "offset": 1133,
    "line": 437,
    "offsetLabel": "opCODECOPYend",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -12544,7 +12789,7 @@
    "inC": "1",
    "CONST": "-32",
    "JMPC": 1,
-   "offset": 1105,
+   "offset": 1128,
    "line": 438,
    "offsetLabel": "opCODECOPYfinal",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -12583,7 +12828,7 @@
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1102",
+   "CONST": "1125",
    "setRR": 1,
    "JMP": 1,
    "offset": 676,
@@ -12607,7 +12852,7 @@
   },
   {
    "JMP": 1,
-   "offset": 1097,
+   "offset": 1120,
    "line": 444,
    "offsetLabel": "opCODECOPYinit",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -12663,7 +12908,7 @@
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1110",
+   "CONST": "1133",
    "setRR": 1,
    "JMP": 1,
    "offset": 710,
@@ -12701,7 +12946,7 @@
    "inB": "1",
    "inE": "-1",
    "JMPC": 1,
-   "offset": 1280,
+   "offset": 1303,
    "line": 456,
    "offsetLabel": "saveMemLength",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -13045,7 +13290,7 @@
    "inC": "1",
    "CONST": "-1",
    "JMPC": 1,
-   "offset": 1153,
+   "offset": 1176,
    "line": 492,
    "offsetLabel": "opEXTCODECOPYend",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -13054,7 +13299,7 @@
    "inC": "1",
    "CONST": "-32",
    "JMPC": 1,
-   "offset": 1148,
+   "offset": 1171,
    "line": 493,
    "offsetLabel": "opEXTCODECOPYfinal",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -13093,7 +13338,7 @@
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1145",
+   "CONST": "1168",
    "setRR": 1,
    "JMP": 1,
    "offset": 676,
@@ -13117,7 +13362,7 @@
   },
   {
    "JMP": 1,
-   "offset": 1140,
+   "offset": 1163,
    "line": 499,
    "offsetLabel": "opEXTCODECOPYinit",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -13173,7 +13418,7 @@
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1153",
+   "CONST": "1176",
    "setRR": 1,
    "JMP": 1,
    "offset": 710,
@@ -13211,7 +13456,7 @@
    "inB": "1",
    "inE": "-1",
    "JMPC": 1,
-   "offset": 1280,
+   "offset": 1303,
    "line": 511,
    "offsetLabel": "saveMemLength",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -13403,7 +13648,7 @@
    "inC": "1",
    "CONST": "-1",
    "JMPC": 1,
-   "offset": 1187,
+   "offset": 1210,
    "line": 533,
    "offsetLabel": "opRETURNDATACOPYend",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -13412,7 +13657,7 @@
    "inC": "1",
    "CONST": "-32",
    "JMPC": 1,
-   "offset": 1181,
+   "offset": 1204,
    "line": 534,
    "offsetLabel": "opRETURNDATACOPYfinal",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -13424,7 +13669,7 @@
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1174",
+   "CONST": "1197",
    "setRR": 1,
    "JMP": 1,
    "offset": 751,
@@ -13454,7 +13699,7 @@
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1178",
+   "CONST": "1201",
    "setRR": 1,
    "JMP": 1,
    "offset": 676,
@@ -13477,7 +13722,7 @@
   },
   {
    "JMP": 1,
-   "offset": 1170,
+   "offset": 1193,
    "line": 543,
    "offsetLabel": "opRETURNDATACOPYinit",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -13489,7 +13734,7 @@
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1183",
+   "CONST": "1206",
    "setRR": 1,
    "JMP": 1,
    "offset": 770,
@@ -13519,7 +13764,7 @@
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1187",
+   "CONST": "1210",
    "setRR": 1,
    "JMP": 1,
    "offset": 710,
@@ -13557,7 +13802,7 @@
    "inB": "1",
    "inE": "-1",
    "JMPC": 1,
-   "offset": 1280,
+   "offset": 1303,
    "line": 556,
    "offsetLabel": "saveMemLength",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -13709,7 +13954,7 @@
    "inC": "1",
    "CONST": "-1",
    "JMPC": 1,
-   "offset": 1211,
+   "offset": 1234,
    "line": 574,
    "offsetLabel": "opEXTCODEHASHend",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -13718,7 +13963,7 @@
    "inC": "1",
    "CONST": "-32",
    "JMPC": 1,
-   "offset": 1208,
+   "offset": 1231,
    "line": 575,
    "offsetLabel": "opEXTCODEHASHfinal",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -13788,7 +14033,7 @@
   },
   {
    "JMP": 1,
-   "offset": 1201,
+   "offset": 1224,
    "line": 580,
    "offsetLabel": "opEXTCODEHASHinit",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -14360,7 +14605,7 @@
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1266",
+   "CONST": "1289",
    "setRR": 1,
    "JMP": 1,
    "offset": 751,
@@ -14405,7 +14650,7 @@
    "inB": "1",
    "inE": "-1",
    "JMPC": 1,
-   "offset": 1280,
+   "offset": 1303,
    "line": 667,
    "offsetLabel": "saveMemLength",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -14470,7 +14715,7 @@
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1276",
+   "CONST": "1299",
    "setRR": 1,
    "JMP": 1,
    "offset": 676,
@@ -14502,7 +14747,7 @@
    "inB": "1",
    "inE": "-1",
    "JMPC": 1,
-   "offset": 1280,
+   "offset": 1303,
    "line": 678,
    "offsetLabel": "saveMemLength",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -14722,7 +14967,7 @@
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1294",
+   "CONST": "1317",
    "setRR": 1,
    "JMP": 1,
    "offset": 710,
@@ -14754,7 +14999,7 @@
    "inB": "1",
    "inE": "-1",
    "JMPC": 1,
-   "offset": 1280,
+   "offset": 1303,
    "line": 700,
    "offsetLabel": "saveMemLength",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -14932,7 +15177,7 @@
    "CONST": "0",
    "inA": "-1",
    "JMPC": 1,
-   "offset": 1314,
+   "offset": 1337,
    "line": 719,
    "offsetLabel": "deploymentSSTORE",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -14952,7 +15197,7 @@
   },
   {
    "JMP": 1,
-   "offset": 1315,
+   "offset": 1338,
    "line": 721,
    "offsetLabel": "opSSTOREinit",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -15080,7 +15325,7 @@
    "inFREE": "1",
    "CONST": "-1",
    "JMPC": 1,
-   "offset": 1326,
+   "offset": 1349,
    "line": 736,
    "offsetLabel": "opSSTOREdif",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -15094,7 +15339,7 @@
   },
   {
    "JMP": 1,
-   "offset": 1354,
+   "offset": 1377,
    "line": 739,
    "offsetLabel": "opSSTOREend",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -15117,7 +15362,7 @@
    "inFREE": "1",
    "CONST": "-1",
    "JMPC": 1,
-   "offset": 1330,
+   "offset": 1353,
    "line": 743,
    "offsetLabel": "opSSTOREdifA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -15140,7 +15385,7 @@
    "inFREE": "1",
    "CONST": "-1",
    "JMPC": 1,
-   "offset": 1349,
+   "offset": 1372,
    "line": 745,
    "offsetLabel": "opSSTOREdifB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -15154,7 +15399,7 @@
   },
   {
    "JMP": 1,
-   "offset": 1354,
+   "offset": 1377,
    "line": 748,
    "offsetLabel": "opSSTOREend",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -15184,14 +15429,14 @@
    "inFREE": "1",
    "CONST": "-1",
    "JMPC": 1,
-   "offset": 1338,
+   "offset": 1361,
    "line": 755,
    "offsetLabel": "opSSTOREdifA1",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 1333,
+   "offset": 1356,
    "line": 757,
    "offsetLabel": "opSSTOREdifAB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -15214,7 +15459,7 @@
    "inFREE": "1",
    "CONST": "-1",
    "JMPC": 1,
-   "offset": 1354,
+   "offset": 1377,
    "line": 760,
    "offsetLabel": "opSSTOREend",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -15237,7 +15482,7 @@
    "inFREE": "1",
    "CONST": "-1",
    "JMPC": 1,
-   "offset": 1346,
+   "offset": 1369,
    "line": 762,
    "offsetLabel": "opSSTOREdifA2",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -15268,7 +15513,7 @@
   },
   {
    "JMP": 1,
-   "offset": 1354,
+   "offset": 1377,
    "line": 766,
    "offsetLabel": "opSSTOREend",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -15291,7 +15536,7 @@
    "inFREE": "1",
    "CONST": "-1",
    "JMPC": 1,
-   "offset": 1342,
+   "offset": 1365,
    "line": 770,
    "offsetLabel": "opSSTOREdifA12",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -15322,7 +15567,7 @@
   },
   {
    "JMP": 1,
-   "offset": 1333,
+   "offset": 1356,
    "line": 774,
    "offsetLabel": "opSSTOREdifAB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -15345,7 +15590,7 @@
    "inFREE": "1",
    "CONST": "-1",
    "JMPC": 1,
-   "offset": 1333,
+   "offset": 1356,
    "line": 777,
    "offsetLabel": "opSSTOREdifAB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -15376,7 +15621,7 @@
   },
   {
    "JMP": 1,
-   "offset": 1333,
+   "offset": 1356,
    "line": 781,
    "offsetLabel": "opSSTOREdifAB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -15407,7 +15652,7 @@
   },
   {
    "JMP": 1,
-   "offset": 1354,
+   "offset": 1377,
    "line": 787,
    "offsetLabel": "opSSTOREend",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -15437,7 +15682,7 @@
    "inFREE": "1",
    "CONST": "-1",
    "JMPC": 1,
-   "offset": 1354,
+   "offset": 1377,
    "line": 792,
    "offsetLabel": "opSSTOREend",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -15468,7 +15713,7 @@
   },
   {
    "JMP": 1,
-   "offset": 1354,
+   "offset": 1377,
    "line": 796,
    "offsetLabel": "opSSTOREend",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -15490,7 +15735,7 @@
    "CONST": "0",
    "inA": "-1",
    "JMPC": 1,
-   "offset": 1358,
+   "offset": 1381,
    "line": 800,
    "offsetLabel": "mloadContract",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -15510,7 +15755,7 @@
   },
   {
    "JMP": 1,
-   "offset": 1359,
+   "offset": 1382,
    "line": 802,
    "offsetLabel": "opSSTOREsr",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -15948,7 +16193,7 @@
    },
    "inFREE": "-1",
    "JMPC": 1,
-   "offset": 1405,
+   "offset": 1428,
    "line": 862,
    "offsetLabel": "opAuxPUSHC",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -16226,14 +16471,14 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 1392,
+   "offset": 1415,
    "line": 889,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 1387,
+   "offset": 1410,
    "line": 890,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -16261,14 +16506,14 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 1392,
+   "offset": 1415,
    "line": 895,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 1387,
+   "offset": 1410,
    "line": 896,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -16296,14 +16541,14 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 1392,
+   "offset": 1415,
    "line": 901,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 1387,
+   "offset": 1410,
    "line": 902,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -16331,14 +16576,14 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 1392,
+   "offset": 1415,
    "line": 907,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 1387,
+   "offset": 1410,
    "line": 908,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -16366,14 +16611,14 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 1392,
+   "offset": 1415,
    "line": 913,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 1387,
+   "offset": 1410,
    "line": 914,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -16401,14 +16646,14 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 1392,
+   "offset": 1415,
    "line": 919,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 1387,
+   "offset": 1410,
    "line": 920,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -16436,14 +16681,14 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 1392,
+   "offset": 1415,
    "line": 925,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 1387,
+   "offset": 1410,
    "line": 926,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -16471,14 +16716,14 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 1392,
+   "offset": 1415,
    "line": 931,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 1387,
+   "offset": 1410,
    "line": 932,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -16506,14 +16751,14 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 1392,
+   "offset": 1415,
    "line": 937,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 1387,
+   "offset": 1410,
    "line": 938,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -16541,14 +16786,14 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 1392,
+   "offset": 1415,
    "line": 943,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 1387,
+   "offset": 1410,
    "line": 944,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -16576,14 +16821,14 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 1392,
+   "offset": 1415,
    "line": 949,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 1387,
+   "offset": 1410,
    "line": 950,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -16611,14 +16856,14 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 1392,
+   "offset": 1415,
    "line": 955,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 1387,
+   "offset": 1410,
    "line": 956,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -16646,14 +16891,14 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 1392,
+   "offset": 1415,
    "line": 961,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 1387,
+   "offset": 1410,
    "line": 962,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -16681,14 +16926,14 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 1392,
+   "offset": 1415,
    "line": 967,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 1387,
+   "offset": 1410,
    "line": 968,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -16716,14 +16961,14 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 1392,
+   "offset": 1415,
    "line": 973,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 1387,
+   "offset": 1410,
    "line": 974,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -16751,14 +16996,14 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 1392,
+   "offset": 1415,
    "line": 979,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 1387,
+   "offset": 1410,
    "line": 980,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -16786,14 +17031,14 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 1392,
+   "offset": 1415,
    "line": 985,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 1387,
+   "offset": 1410,
    "line": 986,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -16821,14 +17066,14 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 1392,
+   "offset": 1415,
    "line": 991,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 1387,
+   "offset": 1410,
    "line": 992,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -16856,14 +17101,14 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 1392,
+   "offset": 1415,
    "line": 997,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 1387,
+   "offset": 1410,
    "line": 998,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -16891,14 +17136,14 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 1392,
+   "offset": 1415,
    "line": 1003,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 1387,
+   "offset": 1410,
    "line": 1004,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -16926,14 +17171,14 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 1392,
+   "offset": 1415,
    "line": 1009,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 1387,
+   "offset": 1410,
    "line": 1010,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -16961,14 +17206,14 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 1392,
+   "offset": 1415,
    "line": 1015,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 1387,
+   "offset": 1410,
    "line": 1016,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -16996,14 +17241,14 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 1392,
+   "offset": 1415,
    "line": 1021,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 1387,
+   "offset": 1410,
    "line": 1022,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -17031,14 +17276,14 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 1392,
+   "offset": 1415,
    "line": 1027,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 1387,
+   "offset": 1410,
    "line": 1028,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -17066,14 +17311,14 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 1392,
+   "offset": 1415,
    "line": 1033,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 1387,
+   "offset": 1410,
    "line": 1034,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -17101,14 +17346,14 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 1392,
+   "offset": 1415,
    "line": 1039,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 1387,
+   "offset": 1410,
    "line": 1040,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -17136,14 +17381,14 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 1392,
+   "offset": 1415,
    "line": 1045,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 1387,
+   "offset": 1410,
    "line": 1046,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -17171,14 +17416,14 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 1392,
+   "offset": 1415,
    "line": 1051,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 1387,
+   "offset": 1410,
    "line": 1052,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -17206,14 +17451,14 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 1392,
+   "offset": 1415,
    "line": 1057,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 1387,
+   "offset": 1410,
    "line": 1058,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -17241,14 +17486,14 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 1392,
+   "offset": 1415,
    "line": 1063,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 1387,
+   "offset": 1410,
    "line": 1064,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -17276,14 +17521,14 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 1392,
+   "offset": 1415,
    "line": 1069,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 1387,
+   "offset": 1410,
    "line": 1070,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -17311,14 +17556,14 @@
    "CONST": "0",
    "inB": "-1",
    "JMPC": 1,
-   "offset": 1392,
+   "offset": 1415,
    "line": 1075,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
    "JMP": 1,
-   "offset": 1387,
+   "offset": 1410,
    "line": 1076,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -19913,7 +20158,7 @@
   },
   {
    "JMP": 1,
-   "offset": 1833,
+   "offset": 1856,
    "line": 1390,
    "offsetLabel": "opLOGLoop",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -20019,7 +20264,7 @@
   },
   {
    "JMP": 1,
-   "offset": 1833,
+   "offset": 1856,
    "line": 1402,
    "offsetLabel": "opLOGLoop",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -20125,7 +20370,7 @@
   },
   {
    "JMP": 1,
-   "offset": 1833,
+   "offset": 1856,
    "line": 1414,
    "offsetLabel": "opLOGLoop",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -20231,7 +20476,7 @@
   },
   {
    "JMP": 1,
-   "offset": 1833,
+   "offset": 1856,
    "line": 1426,
    "offsetLabel": "opLOGLoop",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -20337,7 +20582,7 @@
   },
   {
    "JMP": 1,
-   "offset": 1833,
+   "offset": 1856,
    "line": 1438,
    "offsetLabel": "opLOGLoop",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -20346,7 +20591,7 @@
    "inC": "1",
    "CONST": "-1",
    "JMPC": 1,
-   "offset": 1841,
+   "offset": 1864,
    "line": 1441,
    "offsetLabel": "opSaveTopicsInit",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -20355,13 +20600,13 @@
    "inC": "1",
    "CONST": "-32",
    "JMPC": 1,
-   "offset": 1839,
+   "offset": 1862,
    "line": 1442,
    "offsetLabel": "opLOGFinal",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1836",
+   "CONST": "1859",
    "setRR": 1,
    "JMP": 1,
    "offset": 751,
@@ -20401,13 +20646,13 @@
   },
   {
    "JMP": 1,
-   "offset": 1833,
+   "offset": 1856,
    "line": 1446,
    "offsetLabel": "opLOGLoop",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1840",
+   "CONST": "1863",
    "setRR": 1,
    "JMP": 1,
    "offset": 770,
@@ -20455,7 +20700,7 @@
    "inA": "1",
    "CONST": "-1",
    "JMPC": 1,
-   "offset": 1849,
+   "offset": 1872,
    "line": 1456,
    "offsetLabel": "opLOGend",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -20524,7 +20769,7 @@
   },
   {
    "JMP": 1,
-   "offset": 1842,
+   "offset": 1865,
    "line": 1462,
    "offsetLabel": "opSaveTopicsLoop",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -20559,7 +20804,7 @@
    "inB": "1",
    "inE": "-1",
    "JMPC": 1,
-   "offset": 1280,
+   "offset": 1303,
    "line": 1467,
    "offsetLabel": "saveMemLength",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -21007,7 +21252,7 @@
    "inA": "1",
    "CONST": "-1",
    "JMPC": 1,
-   "offset": 1891,
+   "offset": 1914,
    "line": 1511,
    "offsetLabel": "opCALLend",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -21042,7 +21287,7 @@
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1894",
+   "CONST": "1917",
    "setRR": 1,
    "JMP": 1,
    "offset": 603,
@@ -21519,7 +21764,7 @@
    "inA": "1",
    "CONST": "-1",
    "JMPC": 1,
-   "offset": 1935,
+   "offset": 1958,
    "line": 1567,
    "offsetLabel": "opCALLCODEend",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -21554,7 +21799,7 @@
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1938",
+   "CONST": "1961",
    "setRR": 1,
    "JMP": 1,
    "offset": 603,
@@ -21639,7 +21884,7 @@
    "CONST": "0",
    "inD": "-1",
    "JMPC": 1,
-   "offset": 1982,
+   "offset": 2005,
    "line": 1586,
    "offsetLabel": "opRETURNdeploy",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -21661,7 +21906,7 @@
    "inB": "1",
    "CONST": "-1",
    "JMPC": 1,
-   "offset": 1978,
+   "offset": 2001,
    "line": 1588,
    "offsetLabel": "opRETURNend2",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -21718,7 +21963,7 @@
    "inC": "1",
    "CONST": "-1",
    "JMPC": 1,
-   "offset": 1970,
+   "offset": 1993,
    "line": 1595,
    "offsetLabel": "opRETURNend",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -21727,13 +21972,13 @@
    "inC": "1",
    "CONST": "-32",
    "JMPC": 1,
-   "offset": 1964,
+   "offset": 1987,
    "line": 1596,
    "offsetLabel": "opRETURNfinal",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1954",
+   "CONST": "1977",
    "setRR": 1,
    "JMP": 1,
    "offset": 751,
@@ -21776,7 +22021,7 @@
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1959",
+   "CONST": "1982",
    "setRR": 1,
    "JMP": 1,
    "offset": 676,
@@ -21818,13 +22063,13 @@
   },
   {
    "JMP": 1,
-   "offset": 1951,
+   "offset": 1974,
    "line": 1607,
    "offsetLabel": "opRETURN32",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1965",
+   "CONST": "1988",
    "setRR": 1,
    "JMP": 1,
    "offset": 770,
@@ -21861,7 +22106,7 @@
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1969",
+   "CONST": "1992",
    "setRR": 1,
    "JMP": 1,
    "offset": 710,
@@ -21964,7 +22209,7 @@
    "inB": "1",
    "inE": "-1",
    "JMPC": 1,
-   "offset": 1280,
+   "offset": 1303,
    "line": 1624,
    "offsetLabel": "saveMemLength",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -22006,7 +22251,7 @@
    "inB": "1",
    "inE": "-1",
    "JMPC": 1,
-   "offset": 1280,
+   "offset": 1303,
    "line": 1630,
    "offsetLabel": "saveMemLength",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
@@ -22473,7 +22718,7 @@
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "2022",
+   "CONST": "2045",
    "setRR": 1,
    "JMP": 1,
    "offset": 603,
@@ -22493,6 +22738,280 @@
    "offset": 595,
    "line": 1688,
    "offsetLabel": "invalidTx",
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "CONST": "24000",
+   "offset": 19,
+   "mWR": 1,
+   "line": 1692,
+   "offsetLabel": "gasRefund",
+   "useCTX": 1,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "inGAS": "1",
+   "CONST": "-5000",
+   "setGAS": 1,
+   "line": 1693,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "freeInTag": {
+    "op": ""
+   },
+   "inFREE": "1",
+   "setA": 1,
+   "offset": 1,
+   "mRD": 1,
+   "line": 1696,
+   "offsetLabel": "txDestAddr",
+   "useCTX": 1,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "CONST": "2",
+   "setB": 1,
+   "line": 1697,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "CONST": "0",
+   "setC": 1,
+   "line": 1698,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "CONST": "0",
+   "setD": 1,
+   "line": 1699,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "freeInTag": {
+    "op": ""
+   },
+   "inFREE": "1",
+   "setSR": 1,
+   "sWR": 1,
+   "line": 1700,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "CONST": "0",
+   "setB": 1,
+   "setC": 1,
+   "line": 1703,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "freeInTag": {
+    "op": ""
+   },
+   "inFREE": "1",
+   "setE": 1,
+   "sRD": 1,
+   "line": 1704,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "freeInTag": {
+    "op": ""
+   },
+   "inFREE": "1",
+   "setSR": 1,
+   "sWR": 1,
+   "line": 1707,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "inE": "1",
+   "setD": 1,
+   "line": 1708,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "inSP": "1",
+   "CONST": "-1",
+   "setSP": 1,
+   "line": 1711,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "freeInTag": {
+    "op": ""
+   },
+   "inFREE": "1",
+   "setA": 1,
+   "isStack": 1,
+   "isCode": 0,
+   "isMem": 0,
+   "ind": 0,
+   "incCode": 0,
+   "incStack": 0,
+   "offset": 0,
+   "useCTX": 1,
+   "mRD": 1,
+   "line": 1712,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "inA": "1",
+   "setE": 1,
+   "line": 1715,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "CONST": "2062",
+   "setRR": 1,
+   "JMP": 1,
+   "offset": 803,
+   "line": 1716,
+   "offsetLabel": "ISEMPTY",
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "inGAS": "1",
+   "inE": "-25000",
+   "setGAS": 1,
+   "line": 1717,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "freeInTag": {
+    "op": "functionCall",
+    "funcName": "touchedAddress",
+    "params": [
+     {
+      "op": "getReg",
+      "regName": "A"
+     },
+     {
+      "op": "getReg",
+      "regName": "CTX"
+     }
+    ]
+   },
+   "inFREE": "1",
+   "setE": 1,
+   "line": 1720,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "inGAS": "1",
+   "inE": "-2600",
+   "setGAS": 1,
+   "line": 1721,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "CONST": "0",
+   "setB": 1,
+   "setC": 1,
+   "line": 1724,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "freeInTag": {
+    "op": ""
+   },
+   "inFREE": "1",
+   "setE": 1,
+   "sRD": 1,
+   "line": 1725,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "inD": "1",
+   "setA": 1,
+   "line": 1728,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "inE": "1",
+   "setC": 1,
+   "line": 1729,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "CONST": "1",
+   "setB": 1,
+   "line": 1730,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "CONST": "0",
+   "setD": 1,
+   "line": 1731,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "freeInTag": {
+    "op": "add",
+    "values": [
+     {
+      "op": "getReg",
+      "regName": "A"
+     },
+     {
+      "op": "getReg",
+      "regName": "C"
+     }
+    ]
+   },
+   "inFREE": "1",
+   "setD": 1,
+   "arith": 1,
+   "line": 1732,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "freeInTag": {
+    "op": ""
+   },
+   "inFREE": "1",
+   "setA": 1,
+   "isStack": 1,
+   "isCode": 0,
+   "isMem": 0,
+   "ind": 0,
+   "incCode": 0,
+   "incStack": 0,
+   "offset": 0,
+   "useCTX": 1,
+   "mRD": 1,
+   "line": 1735,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "CONST": "0",
+   "setB": 1,
+   "setC": 1,
+   "line": 1736,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "freeInTag": {
+    "op": ""
+   },
+   "inFREE": "1",
+   "setSR": 1,
+   "sWR": 1,
+   "line": 1737,
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "JMP": 1,
+   "offset": 517,
+   "line": 1739,
+   "offsetLabel": "endCode",
+   "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
+  },
+  {
+   "JMP": 1,
+   "offset": 517,
+   "line": 1742,
+   "offsetLabel": "endCode",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/opcodes.zkasm"
   }
  ],
@@ -22587,192 +23106,197 @@
   "MLOADX": 770,
   "MLOADX2": 785,
   "MLOADend": 799,
-  "opSTOP": 803,
-  "opADD": 804,
-  "opMUL": 813,
-  "opSUB": 822,
-  "opSDIV": 832,
-  "opDIV": 832,
-  "opSMOD": 842,
-  "opMOD": 842,
-  "opADDMOD": 852,
-  "opMULMOD": 864,
-  "opEXP": 876,
-  "set0": 884,
-  "set1": 886,
-  "opSLT": 888,
-  "opLT": 888,
-  "opSGT": 894,
-  "opGT": 894,
-  "opEQ": 900,
-  "opISZERO": 906,
-  "opAND": 911,
-  "opOR": 917,
-  "opXOR": 923,
-  "opNOT": 929,
-  "opBYTE": 934,
-  "opSHR": 942,
-  "opSHL": 950,
-  "opADDRESS": 958,
-  "opADDRESSdeploy": 962,
-  "opADDRESSend": 963,
-  "opBALANCE": 966,
-  "opORIGIN": 974,
-  "opCALLER": 978,
-  "opCALLVALUE": 982,
-  "opCALLDATALOAD": 986,
-  "opCALLDATALOAD2": 998,
-  "opCALLDATASIZE": 1010,
-  "opCALLDATACOPY": 1014,
-  "opCALLDATACOPYinit": 1023,
-  "opCALLDATACOPYfinal": 1041,
-  "opCALLDATACOPYxor": 1060,
-  "opCALLDATACOPYend": 1065,
-  "opCODESIZE": 1070,
-  "oopCODESIZEdep": 1080,
-  "opCODECOPY": 1084,
-  "opCODECOPYinit": 1097,
-  "opCODECOPYfinal": 1105,
-  "opCODECOPYend": 1110,
-  "opGASPRICE": 1114,
-  "opEXTCODESIZE": 1118,
-  "opEXTCODECOPY": 1128,
-  "opEXTCODECOPYinit": 1140,
-  "opEXTCODECOPYfinal": 1148,
-  "opEXTCODECOPYend": 1153,
-  "opRETURNDATASIZE": 1157,
-  "opRETURNDATACOPY": 1161,
-  "opRETURNDATACOPYinit": 1170,
-  "opRETURNDATACOPYfinal": 1181,
-  "opRETURNDATACOPYend": 1187,
-  "opEXTCODEHASH": 1191,
-  "opEXTCODEHASHinit": 1201,
-  "opEXTCODEHASHfinal": 1208,
-  "opEXTCODEHASHend": 1211,
-  "opBLOCKHASH": 1215,
-  "opCOINBASE": 1230,
-  "opTIMESTAMP": 1234,
-  "opNUMBER": 1238,
-  "opDIFFICULTY": 1242,
-  "opGASLIMIT": 1246,
-  "opCHAINID": 1250,
-  "opSELFBALANCE": 1254,
-  "opPOP": 1260,
-  "opMLOAD": 1263,
-  "opMSTORE": 1271,
-  "saveMemLength": 1280,
-  "opMSTORE8": 1286,
-  "opSLOAD": 1298,
-  "opSSTORE": 1307,
-  "deploymentSSTORE": 1314,
-  "opSSTOREinit": 1315,
-  "opSSTOREdif": 1326,
-  "opSSTOREdifA": 1330,
-  "opSSTOREdifAA": 1331,
-  "opSSTOREdifAB": 1333,
-  "opSSTOREdifA1": 1338,
-  "opSSTOREdifA12": 1342,
-  "opSSTOREdifA2": 1346,
-  "opSSTOREdifB": 1349,
-  "opSSTOREend": 1354,
-  "mloadContract": 1358,
-  "opSSTOREsr": 1359,
-  "opJUMP": 1362,
-  "opJUMPI": 1367,
-  "opPC": 1375,
-  "opMSIZE": 1378,
-  "opGAS": 1382,
-  "opJUMPDEST": 1385,
-  "opAuxPUSHA": 1387,
-  "opAuxPUSHB": 1392,
-  "opAuxPUSHC": 1405,
-  "opPUSH1": 1418,
-  "opPUSH2": 1422,
-  "opPUSH3": 1426,
-  "opPUSH4": 1430,
-  "opPUSH5": 1434,
-  "opPUSH6": 1438,
-  "opPUSH7": 1442,
-  "opPUSH8": 1446,
-  "opPUSH9": 1450,
-  "opPUSH10": 1454,
-  "opPUSH11": 1458,
-  "opPUSH12": 1462,
-  "opPUSH13": 1466,
-  "opPUSH14": 1470,
-  "opPUSH15": 1474,
-  "opPUSH16": 1478,
-  "opPUSH17": 1482,
-  "opPUSH18": 1486,
-  "opPUSH19": 1490,
-  "opPUSH20": 1494,
-  "opPUSH21": 1498,
-  "opPUSH22": 1502,
-  "opPUSH23": 1506,
-  "opPUSH24": 1510,
-  "opPUSH25": 1514,
-  "opPUSH26": 1518,
-  "opPUSH27": 1522,
-  "opPUSH28": 1526,
-  "opPUSH29": 1530,
-  "opPUSH30": 1534,
-  "opPUSH31": 1538,
-  "opPUSH32": 1542,
-  "opDUP1": 1546,
-  "opDUP2": 1551,
-  "opDUP3": 1557,
-  "opDUP4": 1563,
-  "opDUP5": 1569,
-  "opDUP6": 1575,
-  "opDUP7": 1581,
-  "opDUP8": 1587,
-  "opDUP9": 1593,
-  "opDUP10": 1599,
-  "opDUP11": 1605,
-  "opDUP12": 1611,
-  "opDUP13": 1617,
-  "opDUP14": 1623,
-  "opDUP15": 1629,
-  "opDUP16": 1635,
-  "opSWAP1": 1641,
-  "opSWAP2": 1648,
-  "opSWAP3": 1657,
-  "opSWAP4": 1666,
-  "opSWAP5": 1675,
-  "opSWAP6": 1684,
-  "opSWAP7": 1693,
-  "opSWAP8": 1702,
-  "opSWAP9": 1711,
-  "opSWAP10": 1720,
-  "opSWAP11": 1729,
-  "opSWAP12": 1738,
-  "opSWAP13": 1747,
-  "opSWAP14": 1756,
-  "opSWAP15": 1765,
-  "opSWAP16": 1774,
-  "opLOG0": 1783,
-  "opLOG1": 1793,
-  "opLOG2": 1803,
-  "opLOG3": 1813,
-  "opLOG4": 1823,
-  "opLOGLoop": 1833,
-  "opLOGFinal": 1839,
-  "opSaveTopicsInit": 1841,
-  "opSaveTopicsLoop": 1842,
-  "opLOGend": 1849,
-  "opCALL": 1853,
-  "opCALLend": 1891,
-  "opCALLCODE": 1895,
-  "opCALLCODEend": 1935,
-  "opRETURN": 1939,
-  "opRETURN32": 1951,
-  "opRETURNfinal": 1964,
-  "opRETURNend": 1970,
-  "opRETURNend2": 1978,
-  "opRETURNdeploy": 1982,
-  "opDELEGATECALL": 1984,
-  "opDELEGATECALLend": 2019,
-  "opREVERT": 2023,
-  "opINVALID": 2024
+  "ISEMPTY": 803,
+  "ISEMPTYSet1": 817,
+  "ISEMPTYSet0": 819,
+  "ISEMPTYEnd": 821,
+  "opSTOP": 826,
+  "opADD": 827,
+  "opMUL": 836,
+  "opSUB": 845,
+  "opSDIV": 855,
+  "opDIV": 855,
+  "opSMOD": 865,
+  "opMOD": 865,
+  "opADDMOD": 875,
+  "opMULMOD": 887,
+  "opEXP": 899,
+  "set0": 907,
+  "set1": 909,
+  "opSLT": 911,
+  "opLT": 911,
+  "opSGT": 917,
+  "opGT": 917,
+  "opEQ": 923,
+  "opISZERO": 929,
+  "opAND": 934,
+  "opOR": 940,
+  "opXOR": 946,
+  "opNOT": 952,
+  "opBYTE": 957,
+  "opSHR": 965,
+  "opSHL": 973,
+  "opADDRESS": 981,
+  "opADDRESSdeploy": 985,
+  "opADDRESSend": 986,
+  "opBALANCE": 989,
+  "opORIGIN": 997,
+  "opCALLER": 1001,
+  "opCALLVALUE": 1005,
+  "opCALLDATALOAD": 1009,
+  "opCALLDATALOAD2": 1021,
+  "opCALLDATASIZE": 1033,
+  "opCALLDATACOPY": 1037,
+  "opCALLDATACOPYinit": 1046,
+  "opCALLDATACOPYfinal": 1064,
+  "opCALLDATACOPYxor": 1083,
+  "opCALLDATACOPYend": 1088,
+  "opCODESIZE": 1093,
+  "oopCODESIZEdep": 1103,
+  "opCODECOPY": 1107,
+  "opCODECOPYinit": 1120,
+  "opCODECOPYfinal": 1128,
+  "opCODECOPYend": 1133,
+  "opGASPRICE": 1137,
+  "opEXTCODESIZE": 1141,
+  "opEXTCODECOPY": 1151,
+  "opEXTCODECOPYinit": 1163,
+  "opEXTCODECOPYfinal": 1171,
+  "opEXTCODECOPYend": 1176,
+  "opRETURNDATASIZE": 1180,
+  "opRETURNDATACOPY": 1184,
+  "opRETURNDATACOPYinit": 1193,
+  "opRETURNDATACOPYfinal": 1204,
+  "opRETURNDATACOPYend": 1210,
+  "opEXTCODEHASH": 1214,
+  "opEXTCODEHASHinit": 1224,
+  "opEXTCODEHASHfinal": 1231,
+  "opEXTCODEHASHend": 1234,
+  "opBLOCKHASH": 1238,
+  "opCOINBASE": 1253,
+  "opTIMESTAMP": 1257,
+  "opNUMBER": 1261,
+  "opDIFFICULTY": 1265,
+  "opGASLIMIT": 1269,
+  "opCHAINID": 1273,
+  "opSELFBALANCE": 1277,
+  "opPOP": 1283,
+  "opMLOAD": 1286,
+  "opMSTORE": 1294,
+  "saveMemLength": 1303,
+  "opMSTORE8": 1309,
+  "opSLOAD": 1321,
+  "opSSTORE": 1330,
+  "deploymentSSTORE": 1337,
+  "opSSTOREinit": 1338,
+  "opSSTOREdif": 1349,
+  "opSSTOREdifA": 1353,
+  "opSSTOREdifAA": 1354,
+  "opSSTOREdifAB": 1356,
+  "opSSTOREdifA1": 1361,
+  "opSSTOREdifA12": 1365,
+  "opSSTOREdifA2": 1369,
+  "opSSTOREdifB": 1372,
+  "opSSTOREend": 1377,
+  "mloadContract": 1381,
+  "opSSTOREsr": 1382,
+  "opJUMP": 1385,
+  "opJUMPI": 1390,
+  "opPC": 1398,
+  "opMSIZE": 1401,
+  "opGAS": 1405,
+  "opJUMPDEST": 1408,
+  "opAuxPUSHA": 1410,
+  "opAuxPUSHB": 1415,
+  "opAuxPUSHC": 1428,
+  "opPUSH1": 1441,
+  "opPUSH2": 1445,
+  "opPUSH3": 1449,
+  "opPUSH4": 1453,
+  "opPUSH5": 1457,
+  "opPUSH6": 1461,
+  "opPUSH7": 1465,
+  "opPUSH8": 1469,
+  "opPUSH9": 1473,
+  "opPUSH10": 1477,
+  "opPUSH11": 1481,
+  "opPUSH12": 1485,
+  "opPUSH13": 1489,
+  "opPUSH14": 1493,
+  "opPUSH15": 1497,
+  "opPUSH16": 1501,
+  "opPUSH17": 1505,
+  "opPUSH18": 1509,
+  "opPUSH19": 1513,
+  "opPUSH20": 1517,
+  "opPUSH21": 1521,
+  "opPUSH22": 1525,
+  "opPUSH23": 1529,
+  "opPUSH24": 1533,
+  "opPUSH25": 1537,
+  "opPUSH26": 1541,
+  "opPUSH27": 1545,
+  "opPUSH28": 1549,
+  "opPUSH29": 1553,
+  "opPUSH30": 1557,
+  "opPUSH31": 1561,
+  "opPUSH32": 1565,
+  "opDUP1": 1569,
+  "opDUP2": 1574,
+  "opDUP3": 1580,
+  "opDUP4": 1586,
+  "opDUP5": 1592,
+  "opDUP6": 1598,
+  "opDUP7": 1604,
+  "opDUP8": 1610,
+  "opDUP9": 1616,
+  "opDUP10": 1622,
+  "opDUP11": 1628,
+  "opDUP12": 1634,
+  "opDUP13": 1640,
+  "opDUP14": 1646,
+  "opDUP15": 1652,
+  "opDUP16": 1658,
+  "opSWAP1": 1664,
+  "opSWAP2": 1671,
+  "opSWAP3": 1680,
+  "opSWAP4": 1689,
+  "opSWAP5": 1698,
+  "opSWAP6": 1707,
+  "opSWAP7": 1716,
+  "opSWAP8": 1725,
+  "opSWAP9": 1734,
+  "opSWAP10": 1743,
+  "opSWAP11": 1752,
+  "opSWAP12": 1761,
+  "opSWAP13": 1770,
+  "opSWAP14": 1779,
+  "opSWAP15": 1788,
+  "opSWAP16": 1797,
+  "opLOG0": 1806,
+  "opLOG1": 1816,
+  "opLOG2": 1826,
+  "opLOG3": 1836,
+  "opLOG4": 1846,
+  "opLOGLoop": 1856,
+  "opLOGFinal": 1862,
+  "opSaveTopicsInit": 1864,
+  "opSaveTopicsLoop": 1865,
+  "opLOGend": 1872,
+  "opCALL": 1876,
+  "opCALLend": 1914,
+  "opCALLCODE": 1918,
+  "opCALLCODEend": 1958,
+  "opRETURN": 1962,
+  "opRETURN32": 1974,
+  "opRETURNfinal": 1987,
+  "opRETURNend": 1993,
+  "opRETURNend2": 2001,
+  "opRETURNdeploy": 2005,
+  "opDELEGATECALL": 2007,
+  "opDELEGATECALLend": 2042,
+  "opREVERT": 2046,
+  "opSELFDESTRUCT": 2047,
+  "opINVALID": 2076
  }
 }

--- a/main/main.zkasm
+++ b/main/main.zkasm
@@ -249,6 +249,3 @@ finalLoop:
 INCLUDE "loadtx_rlp.zkasm"
 INCLUDE "process_tx.zkasm"
 INCLUDE "opcodes.zkasm"
-
-opINVALID:
-

--- a/main/opcodes.zkasm
+++ b/main/opcodes.zkasm
@@ -1687,5 +1687,56 @@ opDELEGATECALLend:
 opREVERT:
                 :JMP(invalidTx)
 
-;opINVALID:
-;opSELFDESTRUCT":
+; // TODO: handle if depth is over 0
+opSELFDESTRUCT:
+    24000               :MSTORE(gasRefund)
+    GAS - 5000 => GAS
+
+    ; clean bytecode
+    $ => A              :MLOAD(txDestAddr)
+    2 => B
+    0 => C
+    0 => D
+    $ => SR             :SSTORE
+
+    ; get contract balance
+    0 => B,C
+    $ => E              :SLOAD
+
+    ; set contract balance to 0
+    $ => SR             :SSTORE
+    E => D              ; contract balance in D
+
+    ; read receiver
+    SP - 1 => SP
+    $ => A              :MLOAD(SP)
+
+    ; gas: check receiver is empty
+    A => E
+                        :CALL(ISEMPTY)
+    GAS - 25000 * E => GAS
+
+    ; gas: check touched address
+    ${touchedAddress(A,CTX)} => E
+    GAS - 2600 * E => GAS
+
+    ; read previous balance receiver
+    0 => B,C
+    $ => E              :SLOAD
+
+    ; compute new receiver balance
+    D => A
+    E => C
+    1 => B
+    0 => D
+    ${A+C} => D         :ARITH
+
+    ; transfer balance to receiver
+    $ => A                  :MLOAD(SP)
+    0 => B,C
+    $ => SR                 :SSTORE
+
+                            :JMP(endCode)
+
+opINVALID:
+    :JMP(endCode)

--- a/main/utils.zkasm
+++ b/main/utils.zkasm
@@ -288,3 +288,43 @@ MLOADend:
     $ => C                      :MLOAD(tmpVarC)
     $ => D                      :MLOAD(tmpVarD)
                                 :RETURN
+
+; @info check account is empty ( balance == nonce == code == 0x )
+; @in E => address
+; @out E => isEmpty
+
+ISEMPTY:
+    A                           :MSTORE(tmpVarA)
+    B                           :MSTORE(tmpVarB)
+    C                           :MSTORE(tmpVarC)
+    D                           :MSTORE(tmpVarD)
+    ; read balance
+    E => A
+    0 => B,C
+    $ => D                      :SLOAD
+    ${comp_eq(D, 0)} - 1        :JMPC(ISEMPTYSet0)
+
+    ; read nonce
+    1 => B
+    $ => D                      :SLOAD
+    ${comp_eq(D, 0)} - 1        :JMPC(ISEMPTYSet0)
+
+    ; read bytecode
+    2 => B
+    $ => D                      :SLOAD
+    ${comp_eq(D, 0)} - 1        :JMPC(ISEMPTYSet0)
+
+ISEMPTYSet1:
+    1 => E
+                                :JMP(ISEMPTYEnd)
+
+ISEMPTYSet0:
+    0 => E
+                                :JMP(ISEMPTYEnd)
+
+ISEMPTYEnd:
+    $ => A                      :MLOAD(tmpVarA)
+    $ => B                      :MLOAD(tmpVarB)
+    $ => C                      :MLOAD(tmpVarC)
+    $ => D                      :MLOAD(tmpVarD)
+                                :RETURN


### PR DESCRIPTION
- add `SELFDESTRUCT` opcode
- change `opINVALID` to `opcodes.zkasm`
- missing handling when depth call is not final 