### PR TITLE
Bug/nonce balance invalid

### DIFF
--- a/main/process_tx.zkasm
+++ b/main/process_tx.zkasm
@@ -65,18 +65,12 @@ endCheckChainId:
         0 => C
         $ => SR                         :SSTORE                                                 ; Store the nonce plus one
 
-; TODO: initSR after nonce (?)
-;;;;;;;;;
-;; Store init state
-;;;;;;;;;
-
-;        SR                              :MSTORE(initSR)
 
 ;;;;;;;;
 ; Buy Gas
 ;;;;;;;;
 
-        $ => A                          :MLOAD(txGas)                                           ; Multiplies the txGas amd the txGasPrice
+        $ => A                          :MLOAD(txGas)                                           ; Multiplies the txGas and the txGasPrice
         $ => B                          :MLOAD(txGasPrice)
         0 => C
         0 => D                                                                                  ; Forces no overflow
@@ -98,8 +92,16 @@ endCheckChainId:
 
         $ => A                          :MLOAD(txSrcOriginAddr)
         0 => B,C
+
+
         $ => SR                         :SSTORE
 
+;;;;;;;;;
+;; Store init state after nonce (for reverted txs) and after checking enough balance
+;;;;;;;;;
+
+        SR                              :MSTORE(initSR)
+        
 ;;;;;;;;
 ; Set the gas
 ;;;;;;;;


### PR DESCRIPTION
- Save SR after nonce check and nonce increase. This way once a transaction is invalid, the nonce is already computed. The nonce has to increase for a reverted/invalid/out of gas transaction
- To discuss on Tuesday: Should we save the SR before or after computing the spent gas of the transaction? I think both approaches are correct as is stored after checking the balance is enough to pay the gas, and the refunded gas is handled in the logic of each opcode

IMPORTANT: Don't merge before Tuesday meet at the office