### PR TITLE
Bug/revert

### DIFF
--- a/main/opcodes.zkasm
+++ b/main/opcodes.zkasm
@@ -2040,7 +2040,7 @@ opREVERT:
                     :JMP(readCode)
 
 opREVERTend:
-                    :JMP(invalidTx)
+                    :JMP(endCode)
 
 ; // TODO: handle if depth is over 0
 opSELFDESTRUCT:


### PR DESCRIPTION
- After a revert opcode, the execution should stop but not treated as invalidtx. In invalid tx the gas is not consumed, but in revert it should