### PR TITLE
Fix intrinsic checks

### DIFF
--- a/build/rom.json
+++ b/build/rom.json
@@ -4973,7 +4973,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1048,
+   "offset": 1054,
    "line": 33,
    "offsetLabel": "MSTORE32",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/precompiled/ecrecover.zkasm"
@@ -5288,7 +5288,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1048,
+   "offset": 1054,
    "line": 28,
    "offsetLabel": "MSTORE32",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/precompiled/sha256.zkasm"
@@ -5580,7 +5580,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1048,
+   "offset": 1054,
    "line": 28,
    "offsetLabel": "MSTORE32",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/precompiled/ripemd160.zkasm"
@@ -5728,7 +5728,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1123,
+   "offset": 1129,
    "line": 14,
    "offsetLabel": "MLOAD32",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/precompiled/identity.zkasm"
@@ -5761,7 +5761,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1048,
+   "offset": 1054,
    "line": 18,
    "offsetLabel": "MSTORE32",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/precompiled/identity.zkasm"
@@ -5800,7 +5800,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1153,
+   "offset": 1159,
    "line": 25,
    "offsetLabel": "MLOADX",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/precompiled/identity.zkasm"
@@ -5827,7 +5827,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1082,
+   "offset": 1088,
    "line": 28,
    "offsetLabel": "MSTOREX",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/precompiled/identity.zkasm"
@@ -5903,7 +5903,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1123,
+   "offset": 1129,
    "line": 12,
    "offsetLabel": "MLOAD32",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/precompiled/modexp.zkasm"
@@ -5924,7 +5924,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1123,
+   "offset": 1129,
    "line": 14,
    "offsetLabel": "MLOAD32",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/precompiled/modexp.zkasm"
@@ -5945,7 +5945,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1123,
+   "offset": 1129,
    "line": 16,
    "offsetLabel": "MLOAD32",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/precompiled/modexp.zkasm"
@@ -5980,7 +5980,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1153,
+   "offset": 1159,
    "line": 19,
    "offsetLabel": "MLOADX",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/precompiled/modexp.zkasm"
@@ -6011,7 +6011,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1153,
+   "offset": 1159,
    "line": 22,
    "offsetLabel": "MLOADX",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/precompiled/modexp.zkasm"
@@ -6052,7 +6052,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1153,
+   "offset": 1159,
    "line": 26,
    "offsetLabel": "MLOADX",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/precompiled/modexp.zkasm"
@@ -6191,7 +6191,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1048,
+   "offset": 1054,
    "line": 38,
    "offsetLabel": "MSTORE32",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/precompiled/modexp.zkasm"
@@ -6211,7 +6211,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1082,
+   "offset": 1088,
    "line": 42,
    "offsetLabel": "MSTOREX",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/precompiled/modexp.zkasm"
@@ -6662,7 +6662,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1123,
+   "offset": 1129,
    "line": 14,
    "offsetLabel": "MLOAD32",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/precompiled/ecadd.zkasm"
@@ -6679,7 +6679,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1123,
+   "offset": 1129,
    "line": 16,
    "offsetLabel": "MLOAD32",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/precompiled/ecadd.zkasm"
@@ -6696,7 +6696,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1123,
+   "offset": 1129,
    "line": 18,
    "offsetLabel": "MLOAD32",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/precompiled/ecadd.zkasm"
@@ -6713,7 +6713,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1123,
+   "offset": 1129,
    "line": 20,
    "offsetLabel": "MLOAD32",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/precompiled/ecadd.zkasm"
@@ -6786,7 +6786,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1048,
+   "offset": 1054,
    "line": 25,
    "offsetLabel": "MSTORE32",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/precompiled/ecadd.zkasm"
@@ -6818,7 +6818,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1048,
+   "offset": 1054,
    "line": 28,
    "offsetLabel": "MSTORE32",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/precompiled/ecadd.zkasm"
@@ -6964,7 +6964,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1123,
+   "offset": 1129,
    "line": 14,
    "offsetLabel": "MLOAD32",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/precompiled/ecmul.zkasm"
@@ -6981,7 +6981,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1123,
+   "offset": 1129,
    "line": 16,
    "offsetLabel": "MLOAD32",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/precompiled/ecmul.zkasm"
@@ -6998,7 +6998,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1123,
+   "offset": 1129,
    "line": 18,
    "offsetLabel": "MLOAD32",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/precompiled/ecmul.zkasm"
@@ -7067,7 +7067,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1048,
+   "offset": 1054,
    "line": 23,
    "offsetLabel": "MSTORE32",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/precompiled/ecmul.zkasm"
@@ -7099,7 +7099,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1048,
+   "offset": 1054,
    "line": 26,
    "offsetLabel": "MSTORE32",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/precompiled/ecmul.zkasm"
@@ -7233,7 +7233,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1123,
+   "offset": 1129,
    "line": 13,
    "offsetLabel": "MLOAD32",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/precompiled/ecpairing.zkasm"
@@ -7310,7 +7310,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1048,
+   "offset": 1054,
    "line": 22,
    "offsetLabel": "MSTORE32",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/precompiled/ecpairing.zkasm"
@@ -7675,7 +7675,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1048,
+   "offset": 1054,
    "line": 33,
    "offsetLabel": "MSTORE32",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/precompiled/blake2f.zkasm"
@@ -7696,7 +7696,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1048,
+   "offset": 1054,
    "line": 35,
    "offsetLabel": "MSTORE32",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/precompiled/blake2f.zkasm"
@@ -7811,7 +7811,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 8,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/precompiled/end.zkasm"
@@ -7887,7 +7887,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 16,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/precompiled/end.zkasm"
@@ -7896,7 +7896,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 867,
+   "offset": 873,
    "line": 19,
    "offsetLabel": "endCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/precompiled/end.zkasm"
@@ -8113,11 +8113,37 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
+   "CONST": "0",
+   "setB": 1,
+   "line": 27,
+   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
+  },
+  {
+   "freeInTag": {
+    "op": ""
+   },
+   "inFREE": "1",
+   "setB": 1,
+   "bin": 1,
+   "binOpcode": 7,
+   "line": 28,
+   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
+  },
+  {
+   "inB": "-1",
+   "JMPC": 0,
+   "JMPN": 1,
+   "offset": 961,
+   "line": 29,
+   "offsetLabel": "invalidTx",
+   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
+  },
+  {
    "inA": "1",
    "offset": 14,
    "mOp": 1,
    "mWR": 1,
-   "line": 26,
+   "line": 30,
    "offsetLabel": "txSrcAddr",
    "useCTX": 1,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -8127,7 +8153,7 @@
    "offset": 15,
    "mOp": 1,
    "mWR": 1,
-   "line": 27,
+   "line": 31,
    "offsetLabel": "txSrcOriginAddr",
    "useCTX": 1,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -8137,7 +8163,7 @@
    "offset": 20,
    "mOp": 1,
    "mWR": 1,
-   "line": 33,
+   "line": 37,
    "offsetLabel": "initSR",
    "useCTX": 1,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -8151,7 +8177,7 @@
    "offset": 11,
    "mOp": 1,
    "mWR": 0,
-   "line": 39,
+   "line": 42,
    "offsetLabel": "txChainId",
    "useCTX": 1,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -8165,7 +8191,7 @@
    "offset": 9,
    "mOp": 1,
    "mWR": 0,
-   "line": 40,
+   "line": 43,
    "offsetLabel": "chainId",
    "useCTX": 0,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -8178,7 +8204,7 @@
    "setC": 1,
    "bin": 1,
    "binOpcode": 7,
-   "line": 41,
+   "line": 44,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -8186,8 +8212,8 @@
    "CONST": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 670,
-   "line": 42,
+   "offset": 673,
+   "line": 45,
    "offsetLabel": "check_defaultChainId",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
@@ -8195,8 +8221,8 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 674,
-   "line": 43,
+   "offset": 677,
+   "line": 46,
    "offsetLabel": "endCheckChainId",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
@@ -8209,7 +8235,7 @@
    "offset": 10,
    "mOp": 1,
    "mWR": 0,
-   "line": 45,
+   "line": 48,
    "offsetLabel": "defaultChainId",
    "useCTX": 0,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -8222,7 +8248,7 @@
    "setC": 1,
    "bin": 1,
    "binOpcode": 7,
-   "line": 46,
+   "line": 49,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -8230,8 +8256,8 @@
    "CONST": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 955,
-   "line": 47,
+   "offset": 961,
+   "line": 50,
    "offsetLabel": "invalidTx",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
@@ -8239,8 +8265,8 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 674,
-   "line": 48,
+   "offset": 677,
+   "line": 51,
    "offsetLabel": "endCheckChainId",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
@@ -8253,7 +8279,7 @@
    "offset": 15,
    "mOp": 1,
    "mWR": 0,
-   "line": 56,
+   "line": 59,
    "offsetLabel": "txSrcOriginAddr",
    "useCTX": 1,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -8274,7 +8300,7 @@
     ]
    },
    "inFREE": "1",
-   "line": 57,
+   "line": 60,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -8287,7 +8313,7 @@
    "offset": 15,
    "mOp": 1,
    "mWR": 0,
-   "line": 63,
+   "line": 66,
    "offsetLabel": "txSrcOriginAddr",
    "useCTX": 1,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -8295,13 +8321,13 @@
   {
    "CONST": "1",
    "setB": 1,
-   "line": 64,
+   "line": 67,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "CONST": "0",
    "setC": 1,
-   "line": 65,
+   "line": 68,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -8311,7 +8337,7 @@
    "inFREE": "1",
    "setA": 1,
    "sRD": 1,
-   "line": 66,
+   "line": 69,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -8323,7 +8349,7 @@
    "offset": 4,
    "mOp": 1,
    "mWR": 0,
-   "line": 67,
+   "line": 70,
    "offsetLabel": "txNonce",
    "useCTX": 1,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -8336,7 +8362,7 @@
    "setC": 1,
    "bin": 1,
    "binOpcode": 7,
-   "line": 68,
+   "line": 71,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -8344,40 +8370,40 @@
    "CONST": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 955,
-   "line": 69,
+   "offset": 961,
+   "line": 72,
    "offsetLabel": "invalidTx",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "inB": "1",
    "assert": 1,
-   "line": 70,
+   "line": 73,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "inA": "1",
    "CONST": "1",
    "setD": 1,
-   "line": 71,
+   "line": 74,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "inE": "1",
    "setA": 1,
-   "line": 72,
+   "line": 75,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "CONST": "1",
    "setB": 1,
-   "line": 73,
+   "line": 76,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "CONST": "0",
    "setC": 1,
-   "line": 74,
+   "line": 77,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -8387,7 +8413,7 @@
    "inFREE": "1",
    "setSR": 1,
    "sWR": 1,
-   "line": 75,
+   "line": 78,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -8399,7 +8425,7 @@
    "offset": 0,
    "mOp": 1,
    "mWR": 0,
-   "line": 81,
+   "line": 84,
    "offsetLabel": "txGas",
    "useCTX": 1,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -8413,7 +8439,7 @@
    "offset": 6,
    "mOp": 1,
    "mWR": 0,
-   "line": 82,
+   "line": 85,
    "offsetLabel": "txGasPrice",
    "useCTX": 1,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -8423,7 +8449,7 @@
    "offset": 37,
    "mOp": 1,
    "mWR": 1,
-   "line": 84,
+   "line": 87,
    "offsetLabel": "arithA",
    "useCTX": 0,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -8433,19 +8459,19 @@
    "offset": 38,
    "mOp": 1,
    "mWR": 1,
-   "line": 85,
+   "line": 88,
    "offsetLabel": "arithB",
    "useCTX": 0,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
-   "CONST": "694",
+   "CONST": "697",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1258,
-   "line": 86,
+   "offset": 1264,
+   "line": 89,
    "offsetLabel": "mulARITH",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
@@ -8458,7 +8484,7 @@
    "offset": 39,
    "mOp": 1,
    "mWR": 0,
-   "line": 87,
+   "line": 90,
    "offsetLabel": "arithRes1",
    "useCTX": 0,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -8472,7 +8498,7 @@
    "offset": 15,
    "mOp": 1,
    "mWR": 0,
-   "line": 89,
+   "line": 92,
    "offsetLabel": "txSrcOriginAddr",
    "useCTX": 1,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -8481,7 +8507,7 @@
    "CONST": "0",
    "setB": 1,
    "setC": 1,
-   "line": 90,
+   "line": 93,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -8491,7 +8517,7 @@
    "inFREE": "1",
    "setE": 1,
    "sRD": 1,
-   "line": 91,
+   "line": 94,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -8499,7 +8525,7 @@
    "offset": 37,
    "mOp": 1,
    "mWR": 1,
-   "line": 94,
+   "line": 97,
    "offsetLabel": "arithA",
    "useCTX": 0,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -8509,19 +8535,78 @@
    "offset": 38,
    "mOp": 1,
    "mWR": 1,
-   "line": 95,
+   "line": 98,
    "offsetLabel": "arithB",
    "useCTX": 0,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
-   "CONST": "701",
+   "CONST": "704",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1249,
-   "line": 96,
+   "offset": 1255,
+   "line": 99,
+   "offsetLabel": "subARITH",
+   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
+  },
+  {
+   "freeInTag": {
+    "op": ""
+   },
+   "inFREE": "1",
+   "setD": 1,
+   "offset": 39,
+   "mOp": 1,
+   "mWR": 0,
+   "line": 101,
+   "offsetLabel": "arithRes1",
+   "useCTX": 0,
+   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
+  },
+  {
+   "freeInTag": {
+    "op": ""
+   },
+   "inFREE": "1",
+   "setA": 1,
+   "offset": 3,
+   "mOp": 1,
+   "mWR": 0,
+   "line": 103,
+   "offsetLabel": "txValue",
+   "useCTX": 1,
+   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
+  },
+  {
+   "inD": "1",
+   "offset": 37,
+   "mOp": 1,
+   "mWR": 1,
+   "line": 104,
+   "offsetLabel": "arithA",
+   "useCTX": 0,
+   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
+  },
+  {
+   "inA": "1",
+   "offset": 38,
+   "mOp": 1,
+   "mWR": 1,
+   "line": 105,
+   "offsetLabel": "arithB",
+   "useCTX": 0,
+   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
+  },
+  {
+   "CONST": "709",
+   "setRR": 1,
+   "JMP": 1,
+   "JMPC": 0,
+   "JMPN": 0,
+   "offset": 1255,
+   "line": 106,
    "offsetLabel": "subARITH",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
@@ -8534,7 +8619,7 @@
    "offset": 39,
    "mOp": 1,
    "mWR": 0,
-   "line": 97,
+   "line": 108,
    "offsetLabel": "arithRes1",
    "useCTX": 0,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -8542,7 +8627,7 @@
   {
    "CONST": "0",
    "setB": 1,
-   "line": 99,
+   "line": 110,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -8553,22 +8638,16 @@
    "setB": 1,
    "bin": 1,
    "binOpcode": 5,
-   "line": 100,
+   "line": 111,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "inB": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 955,
-   "line": 101,
+   "offset": 961,
+   "line": 112,
    "offsetLabel": "invalidTx",
-   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
-  },
-  {
-   "inA": "1",
-   "setD": 1,
-   "line": 103,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -8580,7 +8659,7 @@
    "offset": 15,
    "mOp": 1,
    "mWR": 0,
-   "line": 105,
+   "line": 115,
    "offsetLabel": "txSrcOriginAddr",
    "useCTX": 1,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -8589,7 +8668,7 @@
    "CONST": "0",
    "setB": 1,
    "setC": 1,
-   "line": 106,
+   "line": 116,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -8599,7 +8678,7 @@
    "inFREE": "1",
    "setSR": 1,
    "sWR": 1,
-   "line": 107,
+   "line": 117,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -8607,7 +8686,7 @@
    "offset": 20,
    "mOp": 1,
    "mWR": 1,
-   "line": 116,
+   "line": 124,
    "offsetLabel": "initSR",
    "useCTX": 1,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -8621,7 +8700,7 @@
    "offset": 0,
    "mOp": 1,
    "mWR": 0,
-   "line": 123,
+   "line": 130,
    "offsetLabel": "txGas",
    "useCTX": 1,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -8630,7 +8709,7 @@
    "inGAS": "1",
    "CONST": "-21000",
    "setGAS": 1,
-   "line": 124,
+   "line": 131,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -8642,7 +8721,7 @@
    "offset": 7,
    "mOp": 1,
    "mWR": 0,
-   "line": 129,
+   "line": 136,
    "offsetLabel": "txCalldataLen",
    "useCTX": 1,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -8652,49 +8731,49 @@
    "CONST": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 735,
-   "line": 130,
+   "offset": 743,
+   "line": 137,
    "offsetLabel": "txType",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "CONST": "0",
    "setD": 1,
-   "line": 131,
+   "line": 138,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "CONST": "-1",
    "setC": 1,
-   "line": 132,
+   "line": 139,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "inC": "1",
    "CONST": "1",
    "setC": 1,
-   "line": 135,
+   "line": 142,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "CONST": "0",
    "setD": 1,
-   "line": 136,
+   "line": 143,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "CONST": "1024",
    "inC": "1",
    "setSP": 1,
-   "line": 137,
+   "line": 144,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 720,
-   "line": 138,
+   "offset": 727,
+   "line": 145,
    "offsetLabel": "loopBytes",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
@@ -8703,7 +8782,7 @@
    "offset": 37,
    "mOp": 1,
    "mWR": 1,
-   "line": 141,
+   "line": 148,
    "offsetLabel": "arithA",
    "useCTX": 0,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -8713,19 +8792,19 @@
    "offset": 38,
    "mOp": 1,
    "mWR": 1,
-   "line": 142,
+   "line": 149,
    "offsetLabel": "arithB",
    "useCTX": 0,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
-   "CONST": "723",
+   "CONST": "730",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1258,
-   "line": 143,
+   "offset": 1264,
+   "line": 150,
    "offsetLabel": "mulARITH",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
@@ -8738,7 +8817,7 @@
    "offset": 39,
    "mOp": 1,
    "mWR": 0,
-   "line": 144,
+   "line": 151,
    "offsetLabel": "arithRes1",
    "useCTX": 0,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -8750,8 +8829,8 @@
    "CONST": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 735,
-   "line": 146,
+   "offset": 743,
+   "line": 153,
    "offsetLabel": "txType",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
@@ -8760,8 +8839,8 @@
    "inD": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 716,
-   "line": 147,
+   "offset": 723,
+   "line": 154,
    "offsetLabel": "addGas",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
@@ -8782,7 +8861,7 @@
    "useCTX": 1,
    "mOp": 1,
    "mWR": 0,
-   "line": 148,
+   "line": 155,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -8802,14 +8881,14 @@
    },
    "inFREE": "1",
    "setB": 1,
-   "line": 149,
+   "line": 156,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "inD": "1",
    "CONST": "1",
    "setD": 1,
-   "line": 150,
+   "line": 157,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -8817,8 +8896,8 @@
    "CONST": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 731,
-   "line": 151,
+   "offset": 738,
+   "line": 158,
    "offsetLabel": "add4Gas",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
@@ -8826,8 +8905,8 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 733,
-   "line": 152,
+   "offset": 740,
+   "line": 159,
    "offsetLabel": "add16Gas",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
@@ -8835,15 +8914,15 @@
    "inGAS": "1",
    "CONST": "-4",
    "setGAS": 1,
-   "line": 155,
+   "line": 162,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 720,
-   "line": 156,
+   "offset": 727,
+   "line": 163,
    "offsetLabel": "loopBytes",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
@@ -8851,16 +8930,26 @@
    "inGAS": "1",
    "CONST": "-16",
    "setGAS": 1,
-   "line": 159,
+   "line": 166,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 720,
-   "line": 160,
+   "offset": 727,
+   "line": 167,
    "offsetLabel": "loopBytes",
+   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
+  },
+  {
+   "inSR": "1",
+   "offset": 20,
+   "mOp": 1,
+   "mWR": 1,
+   "line": 172,
+   "offsetLabel": "initSR",
+   "useCTX": 1,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -8872,7 +8961,7 @@
    "offset": 12,
    "mOp": 1,
    "mWR": 0,
-   "line": 165,
+   "line": 178,
    "offsetLabel": "isCreateContract",
    "useCTX": 1,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -8882,8 +8971,8 @@
    "inA": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 751,
-   "line": 166,
+   "offset": 757,
+   "line": 179,
    "offsetLabel": "getContractAddress",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
@@ -8896,7 +8985,7 @@
    "offset": 1,
    "mOp": 1,
    "mWR": 0,
-   "line": 167,
+   "line": 180,
    "offsetLabel": "txDestAddr",
    "useCTX": 1,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -8917,13 +9006,13 @@
     ]
    },
    "inFREE": "1",
-   "line": 168,
+   "line": 181,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "CONST": "10",
    "setB": 1,
-   "line": 170,
+   "line": 183,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -8934,7 +9023,7 @@
    "setB": 1,
    "bin": 1,
    "binOpcode": 3,
-   "line": 171,
+   "line": 184,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -8943,20 +9032,20 @@
    "JMPC": 0,
    "JMPN": 1,
    "offset": 643,
-   "line": 172,
+   "line": 185,
    "offsetLabel": "selectorPrecompiled",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "CONST": "2",
    "setB": 1,
-   "line": 173,
+   "line": 187,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "CONST": "0",
    "setC": 1,
-   "line": 174,
+   "line": 188,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -8966,75 +9055,48 @@
    "inFREE": "1",
    "setA": 1,
    "sRD": 1,
-   "line": 175,
+   "line": 189,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "CONST": "0",
-   "setD": 1,
-   "line": 176,
-   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
-  },
-  {
-   "CONST": "32",
-   "inD": "-1",
-   "JMPC": 0,
-   "JMPN": 1,
-   "offset": 880,
-   "line": 179,
-   "offsetLabel": "moveBalances",
+   "setB": 1,
+   "line": 190,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "freeInTag": {
-    "op": "functionCall",
-    "funcName": "getByte",
-    "params": [
-     {
-      "op": "getReg",
-      "regName": "A"
-     },
-     {
-      "op": "getReg",
-      "regName": "D"
-     }
-    ]
+    "op": ""
    },
    "inFREE": "1",
    "setB": 1,
-   "line": 180,
+   "bin": 1,
+   "binOpcode": 4,
+   "line": 191,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
-   "CONST": "0",
    "inB": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 851,
-   "line": 181,
+   "offset": 857,
+   "line": 192,
    "offsetLabel": "callContract",
-   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
-  },
-  {
-   "inD": "1",
-   "CONST": "1",
-   "setD": 1,
-   "line": 182,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 746,
-   "line": 183,
-   "offsetLabel": "checkTxType",
+   "offset": 886,
+   "line": 193,
+   "offsetLabel": "moveBalances",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "CONST": "0",
    "setHASHPOS": 1,
-   "line": 187,
+   "line": 197,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -9046,7 +9108,7 @@
    "offset": 6,
    "mOp": 1,
    "mWR": 0,
-   "line": 189,
+   "line": 199,
    "offsetLabel": "lastHashIdUsed",
    "useCTX": 0,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -9058,7 +9120,7 @@
    "offset": 6,
    "mOp": 1,
    "mWR": 1,
-   "line": 190,
+   "line": 200,
    "offsetLabel": "lastHashIdUsed",
    "useCTX": 0,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -9072,7 +9134,7 @@
    "offset": 34,
    "mOp": 1,
    "mWR": 0,
-   "line": 191,
+   "line": 201,
    "offsetLabel": "isCreate2",
    "useCTX": 1,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -9082,8 +9144,8 @@
    "inA": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 787,
-   "line": 192,
+   "offset": 793,
+   "line": 202,
    "offsetLabel": "create2",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
@@ -9096,7 +9158,7 @@
    "offset": 14,
    "mOp": 1,
    "mWR": 0,
-   "line": 193,
+   "line": 203,
    "offsetLabel": "txSrcAddr",
    "useCTX": 1,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -9110,7 +9172,7 @@
    "offset": 4,
    "mOp": 1,
    "mWR": 0,
-   "line": 194,
+   "line": 204,
    "offsetLabel": "txNonce",
    "useCTX": 1,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -9120,8 +9182,8 @@
    "CONST": "-128",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 770,
-   "line": 195,
+   "offset": 776,
+   "line": 205,
    "offsetLabel": "nonce1byte",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
@@ -9134,7 +9196,7 @@
    "offset": 5,
    "mOp": 1,
    "mWR": 0,
-   "line": 196,
+   "line": 206,
    "offsetLabel": "lengthNonce",
    "useCTX": 1,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -9142,7 +9204,7 @@
   {
    "CONST": "1",
    "setD": 1,
-   "line": 197,
+   "line": 207,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -9152,7 +9214,7 @@
    "indRR": 0,
    "offset": 0,
    "hashK": 1,
-   "line": 198,
+   "line": 208,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -9161,13 +9223,13 @@
    "indRR": 0,
    "offset": 0,
    "hashK": 1,
-   "line": 199,
+   "line": 209,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "CONST": "20",
    "setD": 1,
-   "line": 200,
+   "line": 210,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -9176,13 +9238,13 @@
    "indRR": 0,
    "offset": 0,
    "hashK": 1,
-   "line": 201,
+   "line": 211,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "CONST": "1",
    "setD": 1,
-   "line": 202,
+   "line": 212,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -9192,13 +9254,13 @@
    "indRR": 0,
    "offset": 0,
    "hashK": 1,
-   "line": 203,
+   "line": 213,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "inC": "1",
    "setD": 1,
-   "line": 204,
+   "line": 214,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -9207,22 +9269,22 @@
    "indRR": 0,
    "offset": 0,
    "hashK": 1,
-   "line": 205,
+   "line": 215,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 780,
-   "line": 206,
+   "offset": 786,
+   "line": 216,
    "offsetLabel": "endContractAddress",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "CONST": "1",
    "setD": 1,
-   "line": 209,
+   "line": 219,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -9231,7 +9293,7 @@
    "indRR": 0,
    "offset": 0,
    "hashK": 1,
-   "line": 210,
+   "line": 220,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -9240,13 +9302,13 @@
    "indRR": 0,
    "offset": 0,
    "hashK": 1,
-   "line": 211,
+   "line": 221,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "CONST": "20",
    "setD": 1,
-   "line": 212,
+   "line": 222,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -9255,13 +9317,13 @@
    "indRR": 0,
    "offset": 0,
    "hashK": 1,
-   "line": 213,
+   "line": 223,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "CONST": "1",
    "setD": 1,
-   "line": 214,
+   "line": 224,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -9269,8 +9331,8 @@
    "CONST": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 779,
-   "line": 215,
+   "offset": 785,
+   "line": 225,
    "offsetLabel": "nonceIs0",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
@@ -9280,15 +9342,15 @@
    "indRR": 0,
    "offset": 0,
    "hashK": 1,
-   "line": 216,
+   "line": 226,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 780,
-   "line": 217,
+   "offset": 786,
+   "line": 227,
    "offsetLabel": "endContractAddress",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
@@ -9298,7 +9360,7 @@
    "indRR": 0,
    "offset": 0,
    "hashK": 1,
-   "line": 220,
+   "line": 230,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -9307,7 +9369,7 @@
    "indRR": 0,
    "offset": 0,
    "hashKLen": 1,
-   "line": 223,
+   "line": 233,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -9320,13 +9382,13 @@
    "indRR": 0,
    "offset": 0,
    "hashKDigest": 1,
-   "line": 224,
+   "line": 234,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "CONST": "12",
    "setD": 1,
-   "line": 225,
+   "line": 235,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -9354,7 +9416,7 @@
    },
    "inFREE": "1",
    "setA": 1,
-   "line": 226,
+   "line": 236,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -9382,7 +9444,7 @@
    },
    "inFREE": "1",
    "setA": 1,
-   "line": 227,
+   "line": 237,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -9390,7 +9452,7 @@
    "offset": 13,
    "mOp": 1,
    "mWR": 1,
-   "line": 228,
+   "line": 238,
    "offsetLabel": "createContractAddress",
    "useCTX": 1,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -9399,8 +9461,8 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 829,
-   "line": 231,
+   "offset": 835,
+   "line": 241,
    "offsetLabel": "deploy",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
@@ -9413,7 +9475,7 @@
    "offset": 7,
    "mOp": 1,
    "mWR": 0,
-   "line": 234,
+   "line": 244,
    "offsetLabel": "txCalldataLen",
    "useCTX": 1,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -9443,7 +9505,7 @@
    },
    "inFREE": "1",
    "setA": 1,
-   "line": 236,
+   "line": 246,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -9464,7 +9526,7 @@
    "offset": 37,
    "mOp": 1,
    "mWR": 1,
-   "line": 238,
+   "line": 248,
    "offsetLabel": "arithA",
    "useCTX": 0,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -9474,19 +9536,19 @@
    "offset": 38,
    "mOp": 1,
    "mWR": 1,
-   "line": 239,
+   "line": 249,
    "offsetLabel": "arithB",
    "useCTX": 0,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
-   "CONST": "792",
+   "CONST": "798",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1269,
-   "line": 240,
+   "offset": 1275,
+   "line": 250,
    "offsetLabel": "divARITH",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
@@ -9499,7 +9561,7 @@
    "offset": 39,
    "mOp": 1,
    "mWR": 0,
-   "line": 241,
+   "line": 251,
    "offsetLabel": "arithRes1",
    "useCTX": 0,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -9508,21 +9570,21 @@
    "inGAS": "1",
    "inA": "-6",
    "setGAS": 1,
-   "line": 243,
+   "line": 253,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "CONST": "1024",
    "setSP": 1,
-   "line": 244,
+   "line": 254,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 796,
-   "line": 245,
+   "offset": 802,
+   "line": 255,
    "offsetLabel": "loopCreate2",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
@@ -9531,8 +9593,8 @@
    "CONST": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 808,
-   "line": 248,
+   "offset": 814,
+   "line": 258,
    "offsetLabel": "create2end",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
@@ -9541,8 +9603,8 @@
    "CONST": "-32",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 803,
-   "line": 249,
+   "offset": 809,
+   "line": 259,
    "offsetLabel": "endloopCreate2",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
@@ -9562,13 +9624,13 @@
    "useCTX": 1,
    "mOp": 1,
    "mWR": 0,
-   "line": 250,
+   "line": 260,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "CONST": "32",
    "setD": 1,
-   "line": 251,
+   "line": 261,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -9577,22 +9639,22 @@
    "indRR": 0,
    "offset": 0,
    "hashK": 1,
-   "line": 252,
+   "line": 262,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "inC": "1",
    "CONST": "-32",
    "setC": 1,
-   "line": 253,
+   "line": 263,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 796,
-   "line": 254,
+   "offset": 802,
+   "line": 264,
    "offsetLabel": "loopCreate2",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
@@ -9613,14 +9675,14 @@
    "useCTX": 1,
    "mOp": 1,
    "mWR": 0,
-   "line": 257,
+   "line": 267,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "CONST": "32",
    "inC": "-1",
    "setD": 1,
-   "line": 258,
+   "line": 268,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -9648,13 +9710,13 @@
    },
    "inFREE": "1",
    "setA": 1,
-   "line": 259,
+   "line": 269,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "inC": "1",
    "setD": 1,
-   "line": 260,
+   "line": 270,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -9663,7 +9725,7 @@
    "indRR": 0,
    "offset": 0,
    "hashK": 1,
-   "line": 261,
+   "line": 271,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -9672,7 +9734,7 @@
    "indRR": 0,
    "offset": 0,
    "hashKLen": 1,
-   "line": 264,
+   "line": 274,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -9685,13 +9747,13 @@
    "indRR": 0,
    "offset": 0,
    "hashKDigest": 1,
-   "line": 265,
+   "line": 275,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "CONST": "0",
    "setHASHPOS": 1,
-   "line": 267,
+   "line": 277,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -9703,7 +9765,7 @@
    "offset": 6,
    "mOp": 1,
    "mWR": 0,
-   "line": 268,
+   "line": 278,
    "offsetLabel": "lastHashIdUsed",
    "useCTX": 0,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -9715,7 +9777,7 @@
    "offset": 6,
    "mOp": 1,
    "mWR": 1,
-   "line": 269,
+   "line": 279,
    "offsetLabel": "lastHashIdUsed",
    "useCTX": 0,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -9723,7 +9785,7 @@
   {
    "CONST": "1",
    "setD": 1,
-   "line": 271,
+   "line": 281,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -9732,13 +9794,13 @@
    "indRR": 0,
    "offset": 0,
    "hashK": 1,
-   "line": 272,
+   "line": 282,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "CONST": "20",
    "setD": 1,
-   "line": 273,
+   "line": 283,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -9750,7 +9812,7 @@
    "offset": 14,
    "mOp": 1,
    "mWR": 0,
-   "line": 274,
+   "line": 284,
    "offsetLabel": "txSrcAddr",
    "useCTX": 1,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -9761,7 +9823,7 @@
    "indRR": 0,
    "offset": 0,
    "hashK": 1,
-   "line": 275,
+   "line": 285,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -9773,7 +9835,7 @@
    "offset": 35,
    "mOp": 1,
    "mWR": 0,
-   "line": 276,
+   "line": 286,
    "offsetLabel": "salt",
    "useCTX": 1,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -9781,7 +9843,7 @@
   {
    "CONST": "32",
    "setD": 1,
-   "line": 277,
+   "line": 287,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -9790,13 +9852,13 @@
    "indRR": 0,
    "offset": 0,
    "hashK": 1,
-   "line": 278,
+   "line": 288,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "CONST": "32",
    "setD": 1,
-   "line": 279,
+   "line": 289,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -9805,7 +9867,7 @@
    "indRR": 0,
    "offset": 0,
    "hashK": 1,
-   "line": 280,
+   "line": 290,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -9814,7 +9876,7 @@
    "indRR": 0,
    "offset": 0,
    "hashKLen": 1,
-   "line": 281,
+   "line": 291,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -9827,13 +9889,13 @@
    "indRR": 0,
    "offset": 0,
    "hashKDigest": 1,
-   "line": 282,
+   "line": 292,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "CONST": "12",
    "setD": 1,
-   "line": 283,
+   "line": 293,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -9861,7 +9923,7 @@
    },
    "inFREE": "1",
    "setA": 1,
-   "line": 284,
+   "line": 294,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -9889,7 +9951,7 @@
    },
    "inFREE": "1",
    "setA": 1,
-   "line": 285,
+   "line": 295,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -9897,7 +9959,7 @@
    "offset": 13,
    "mOp": 1,
    "mWR": 1,
-   "line": 286,
+   "line": 296,
    "offsetLabel": "createContractAddress",
    "useCTX": 1,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -9907,7 +9969,7 @@
    "offset": 9,
    "mOp": 1,
    "mWR": 1,
-   "line": 289,
+   "line": 299,
    "offsetLabel": "SPr",
    "useCTX": 1,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -9917,7 +9979,7 @@
    "offset": 10,
    "mOp": 1,
    "mWR": 1,
-   "line": 290,
+   "line": 300,
    "offsetLabel": "SPw",
    "useCTX": 1,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -9925,28 +9987,28 @@
   {
    "CONST": "0",
    "setPC": 1,
-   "line": 291,
+   "line": 301,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "CONST": "0",
    "setSP": 1,
-   "line": 292,
+   "line": 302,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "inGAS": "1",
    "CONST": "-32000",
    "setGAS": 1,
-   "line": 293,
+   "line": 303,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
-   "line": 294,
+   "offset": 870,
+   "line": 304,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
@@ -9955,7 +10017,7 @@
    "offset": 10,
    "mOp": 1,
    "mWR": 1,
-   "line": 297,
+   "line": 307,
    "offsetLabel": "SPw",
    "useCTX": 1,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -9969,7 +10031,7 @@
    "offset": 9,
    "mOp": 1,
    "mWR": 0,
-   "line": 298,
+   "line": 308,
    "offsetLabel": "SPr",
    "useCTX": 1,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -9979,7 +10041,7 @@
    "offset": 37,
    "mOp": 1,
    "mWR": 1,
-   "line": 300,
+   "line": 310,
    "offsetLabel": "arithA",
    "useCTX": 0,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -9989,19 +10051,19 @@
    "offset": 38,
    "mOp": 1,
    "mWR": 1,
-   "line": 301,
+   "line": 311,
    "offsetLabel": "arithB",
    "useCTX": 0,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
-   "CONST": "840",
+   "CONST": "846",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1269,
-   "line": 302,
+   "offset": 1275,
+   "line": 312,
    "offsetLabel": "divARITH",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
@@ -10014,7 +10076,7 @@
    "offset": 39,
    "mOp": 1,
    "mWR": 0,
-   "line": 303,
+   "line": 313,
    "offsetLabel": "arithRes1",
    "useCTX": 0,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -10028,7 +10090,7 @@
    "offset": 40,
    "mOp": 1,
    "mWR": 0,
-   "line": 304,
+   "line": 314,
    "offsetLabel": "arithRes2",
    "useCTX": 0,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -10037,7 +10099,7 @@
    "inSP": "1",
    "inA": "1",
    "setSP": 1,
-   "line": 306,
+   "line": 316,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -10049,7 +10111,7 @@
    "offset": 7,
    "mOp": 1,
    "mWR": 0,
-   "line": 308,
+   "line": 318,
    "offsetLabel": "txCalldataLen",
    "useCTX": 1,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -10059,8 +10121,8 @@
    "inPC": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 870,
-   "line": 309,
+   "offset": 876,
+   "line": 319,
    "offsetLabel": "endDeploy",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
@@ -10081,7 +10143,7 @@
    "useCTX": 1,
    "mOp": 1,
    "mWR": 0,
-   "line": 310,
+   "line": 320,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -10093,7 +10155,7 @@
    "offset": 10,
    "mOp": 1,
    "mWR": 0,
-   "line": 311,
+   "line": 321,
    "offsetLabel": "SPw",
    "useCTX": 1,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -10115,7 +10177,7 @@
    },
    "inFREE": "1",
    "setB": 1,
-   "line": 312,
+   "line": 322,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -10131,14 +10193,14 @@
    },
    "inFREE": "1",
    "setRR": 1,
-   "line": 313,
+   "line": 323,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "inPC": "1",
    "CONST": "1",
    "setPC": 1,
-   "line": 314,
+   "line": 324,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -10148,27 +10210,27 @@
    "ind": 0,
    "indRR": 1,
    "offset": 0,
-   "line": 315,
+   "line": 325,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "CONST": "0",
    "setPC": 1,
-   "line": 318,
+   "line": 328,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "CONST": "0",
    "setSP": 1,
-   "line": 319,
+   "line": 329,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
-   "line": 320,
+   "offset": 870,
+   "line": 330,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
@@ -10181,7 +10243,7 @@
    "offset": 1,
    "mOp": 1,
    "mWR": 0,
-   "line": 323,
+   "line": 333,
    "offsetLabel": "txDestAddr",
    "useCTX": 1,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -10189,13 +10251,13 @@
   {
    "CONST": "2",
    "setB": 1,
-   "line": 324,
+   "line": 334,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "CONST": "0",
    "setC": 1,
-   "line": 325,
+   "line": 335,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -10205,7 +10267,7 @@
    "inFREE": "1",
    "setA": 1,
    "sRD": 1,
-   "line": 326,
+   "line": 336,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -10221,7 +10283,7 @@
    },
    "inFREE": "1",
    "setB": 1,
-   "line": 327,
+   "line": 337,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -10229,8 +10291,8 @@
    "inPC": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 880,
-   "line": 328,
+   "offset": 886,
+   "line": 338,
    "offsetLabel": "endByteCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
@@ -10251,7 +10313,7 @@
    },
    "inFREE": "1",
    "setB": 1,
-   "line": 329,
+   "line": 339,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -10267,14 +10329,14 @@
    },
    "inFREE": "1",
    "setRR": 1,
-   "line": 330,
+   "line": 340,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "inPC": "1",
    "CONST": "1",
    "setPC": 1,
-   "line": 331,
+   "line": 341,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -10284,7 +10346,7 @@
    "ind": 0,
    "indRR": 1,
    "offset": 0,
-   "line": 332,
+   "line": 342,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -10296,7 +10358,7 @@
    "offset": 12,
    "mOp": 1,
    "mWR": 0,
-   "line": 335,
+   "line": 345,
    "offsetLabel": "isCreateContract",
    "useCTX": 1,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -10306,8 +10368,8 @@
    "inA": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 835,
-   "line": 336,
+   "offset": 841,
+   "line": 346,
    "offsetLabel": "readDeployBytecode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
@@ -10315,8 +10377,8 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 854,
-   "line": 337,
+   "offset": 860,
+   "line": 347,
    "offsetLabel": "readByteCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
@@ -10329,7 +10391,7 @@
    "offset": 12,
    "mOp": 1,
    "mWR": 0,
-   "line": 340,
+   "line": 350,
    "offsetLabel": "isCreateContract",
    "useCTX": 1,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -10339,8 +10401,8 @@
    "inA": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 870,
-   "line": 341,
+   "offset": 876,
+   "line": 351,
    "offsetLabel": "endDeploy",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
@@ -10348,8 +10410,8 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 880,
-   "line": 342,
+   "offset": 886,
+   "line": 352,
    "offsetLabel": "endByteCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
@@ -10362,7 +10424,7 @@
    "offset": 13,
    "mOp": 1,
    "mWR": 0,
-   "line": 347,
+   "line": 357,
    "offsetLabel": "createContractAddress",
    "useCTX": 1,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -10370,19 +10432,19 @@
   {
    "CONST": "1",
    "setB": 1,
-   "line": 348,
+   "line": 358,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "CONST": "0",
    "setC": 1,
-   "line": 349,
+   "line": 359,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "CONST": "1",
    "setD": 1,
-   "line": 350,
+   "line": 360,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -10392,7 +10454,7 @@
    "inFREE": "1",
    "setSR": 1,
    "sWR": 1,
-   "line": 351,
+   "line": 361,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -10400,7 +10462,7 @@
    "offset": 1,
    "mOp": 1,
    "mWR": 1,
-   "line": 353,
+   "line": 363,
    "offsetLabel": "txDestAddr",
    "useCTX": 1,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -10418,19 +10480,19 @@
    },
    "inFREE": "1",
    "setD": 1,
-   "line": 356,
+   "line": 366,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "CONST": "2",
    "setB": 1,
-   "line": 357,
+   "line": 367,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "CONST": "0",
    "setC": 1,
-   "line": 358,
+   "line": 368,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -10440,7 +10502,7 @@
    "inFREE": "1",
    "setSR": 1,
    "sWR": 1,
-   "line": 359,
+   "line": 369,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -10452,7 +10514,7 @@
    "offset": 14,
    "mOp": 1,
    "mWR": 0,
-   "line": 370,
+   "line": 380,
    "offsetLabel": "txSrcAddr",
    "useCTX": 1,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -10461,7 +10523,7 @@
    "CONST": "0",
    "setB": 1,
    "setC": 1,
-   "line": 371,
+   "line": 381,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -10471,7 +10533,7 @@
    "inFREE": "1",
    "setE": 1,
    "sRD": 1,
-   "line": 372,
+   "line": 382,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -10483,7 +10545,7 @@
    "offset": 3,
    "mOp": 1,
    "mWR": 0,
-   "line": 373,
+   "line": 383,
    "offsetLabel": "txValue",
    "useCTX": 1,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -10493,7 +10555,7 @@
    "offset": 37,
    "mOp": 1,
    "mWR": 1,
-   "line": 375,
+   "line": 385,
    "offsetLabel": "arithA",
    "useCTX": 0,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -10503,19 +10565,19 @@
    "offset": 38,
    "mOp": 1,
    "mWR": 1,
-   "line": 376,
+   "line": 386,
    "offsetLabel": "arithB",
    "useCTX": 0,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
-   "CONST": "887",
+   "CONST": "893",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1249,
-   "line": 377,
+   "offset": 1255,
+   "line": 387,
    "offsetLabel": "subARITH",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
@@ -10528,7 +10590,7 @@
    "offset": 39,
    "mOp": 1,
    "mWR": 0,
-   "line": 378,
+   "line": 388,
    "offsetLabel": "arithRes1",
    "useCTX": 0,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -10536,7 +10598,7 @@
   {
    "CONST": "31",
    "setD": 1,
-   "line": 380,
+   "line": 390,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -10564,7 +10626,7 @@
    },
    "inFREE": "1",
    "setB": 1,
-   "line": 381,
+   "line": 391,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -10572,27 +10634,27 @@
    "inB": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 955,
-   "line": 382,
+   "offset": 961,
+   "line": 392,
    "offsetLabel": "invalidTx",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "CONST": "1",
    "setB": 1,
-   "line": 383,
+   "line": 393,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "CONST": "0",
    "setD": 1,
-   "line": 384,
+   "line": 394,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "inA": "1",
    "setD": 1,
-   "line": 385,
+   "line": 395,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -10604,7 +10666,7 @@
    "offset": 14,
    "mOp": 1,
    "mWR": 0,
-   "line": 386,
+   "line": 396,
    "offsetLabel": "txSrcAddr",
    "useCTX": 1,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -10613,7 +10675,7 @@
    "CONST": "0",
    "setB": 1,
    "setC": 1,
-   "line": 387,
+   "line": 397,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -10623,97 +10685,7 @@
    "inFREE": "1",
    "setSR": 1,
    "sWR": 1,
-   "line": 388,
-   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
-  },
-  {
-   "freeInTag": {
-    "op": ""
-   },
-   "inFREE": "1",
-   "setA": 1,
-   "offset": 1,
-   "mOp": 1,
-   "mWR": 0,
-   "line": 391,
-   "offsetLabel": "txDestAddr",
-   "useCTX": 1,
-   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
-  },
-  {
-   "CONST": "0",
-   "setB": 1,
-   "setC": 1,
-   "line": 392,
-   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
-  },
-  {
-   "freeInTag": {
-    "op": ""
-   },
-   "inFREE": "1",
-   "setC": 1,
-   "sRD": 1,
-   "line": 393,
-   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
-  },
-  {
-   "freeInTag": {
-    "op": ""
-   },
-   "inFREE": "1",
-   "setA": 1,
-   "offset": 3,
-   "mOp": 1,
-   "mWR": 0,
-   "line": 394,
-   "offsetLabel": "txValue",
-   "useCTX": 1,
-   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
-  },
-  {
-   "inA": "1",
-   "offset": 37,
-   "mOp": 1,
-   "mWR": 1,
-   "line": 396,
-   "offsetLabel": "arithA",
-   "useCTX": 0,
-   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
-  },
-  {
-   "inC": "1",
-   "offset": 38,
-   "mOp": 1,
-   "mWR": 1,
-   "line": 397,
-   "offsetLabel": "arithB",
-   "useCTX": 0,
-   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
-  },
-  {
-   "CONST": "904",
-   "setRR": 1,
-   "JMP": 1,
-   "JMPC": 0,
-   "JMPN": 0,
-   "offset": 1240,
    "line": 398,
-   "offsetLabel": "addARITH",
-   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
-  },
-  {
-   "freeInTag": {
-    "op": ""
-   },
-   "inFREE": "1",
-   "setD": 1,
-   "offset": 39,
-   "mOp": 1,
-   "mWR": 0,
-   "line": 399,
-   "offsetLabel": "arithRes1",
-   "useCTX": 0,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -10742,15 +10714,105 @@
     "op": ""
    },
    "inFREE": "1",
+   "setC": 1,
+   "sRD": 1,
+   "line": 403,
+   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
+  },
+  {
+   "freeInTag": {
+    "op": ""
+   },
+   "inFREE": "1",
+   "setA": 1,
+   "offset": 3,
+   "mOp": 1,
+   "mWR": 0,
+   "line": 404,
+   "offsetLabel": "txValue",
+   "useCTX": 1,
+   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
+  },
+  {
+   "inA": "1",
+   "offset": 37,
+   "mOp": 1,
+   "mWR": 1,
+   "line": 406,
+   "offsetLabel": "arithA",
+   "useCTX": 0,
+   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
+  },
+  {
+   "inC": "1",
+   "offset": 38,
+   "mOp": 1,
+   "mWR": 1,
+   "line": 407,
+   "offsetLabel": "arithB",
+   "useCTX": 0,
+   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
+  },
+  {
+   "CONST": "910",
+   "setRR": 1,
+   "JMP": 1,
+   "JMPC": 0,
+   "JMPN": 0,
+   "offset": 1246,
+   "line": 408,
+   "offsetLabel": "addARITH",
+   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
+  },
+  {
+   "freeInTag": {
+    "op": ""
+   },
+   "inFREE": "1",
+   "setD": 1,
+   "offset": 39,
+   "mOp": 1,
+   "mWR": 0,
+   "line": 409,
+   "offsetLabel": "arithRes1",
+   "useCTX": 0,
+   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
+  },
+  {
+   "freeInTag": {
+    "op": ""
+   },
+   "inFREE": "1",
+   "setA": 1,
+   "offset": 1,
+   "mOp": 1,
+   "mWR": 0,
+   "line": 411,
+   "offsetLabel": "txDestAddr",
+   "useCTX": 1,
+   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
+  },
+  {
+   "CONST": "0",
+   "setB": 1,
+   "setC": 1,
+   "line": 412,
+   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
+  },
+  {
+   "freeInTag": {
+    "op": ""
+   },
+   "inFREE": "1",
    "setSR": 1,
    "sWR": 1,
-   "line": 403,
+   "line": 413,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "CONST": "0",
    "setA": 1,
-   "line": 411,
+   "line": 421,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -10762,7 +10824,7 @@
    "offset": 19,
    "mOp": 1,
    "mWR": 0,
-   "line": 412,
+   "line": 422,
    "offsetLabel": "gasRefund",
    "useCTX": 1,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -10772,8 +10834,8 @@
    "CONST": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 919,
-   "line": 413,
+   "offset": 925,
+   "line": 423,
    "offsetLabel": "refundGas",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
@@ -10786,7 +10848,7 @@
    "offset": 0,
    "mOp": 1,
    "mWR": 0,
-   "line": 414,
+   "line": 424,
    "offsetLabel": "txGas",
    "useCTX": 1,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -10795,7 +10857,7 @@
    "inA": "1",
    "inGAS": "-1",
    "setA": 1,
-   "line": 415,
+   "line": 425,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -10803,7 +10865,7 @@
    "offset": 37,
    "mOp": 1,
    "mWR": 1,
-   "line": 417,
+   "line": 427,
    "offsetLabel": "arithA",
    "useCTX": 0,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -10813,19 +10875,19 @@
    "offset": 38,
    "mOp": 1,
    "mWR": 1,
-   "line": 418,
+   "line": 428,
    "offsetLabel": "arithB",
    "useCTX": 0,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
-   "CONST": "916",
+   "CONST": "922",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1269,
-   "line": 419,
+   "offset": 1275,
+   "line": 429,
    "offsetLabel": "divARITH",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
@@ -10838,7 +10900,7 @@
    "offset": 39,
    "mOp": 1,
    "mWR": 0,
-   "line": 420,
+   "line": 430,
    "offsetLabel": "arithRes1",
    "useCTX": 0,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -10848,28 +10910,28 @@
    "inB": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 919,
-   "line": 421,
+   "offset": 925,
+   "line": 431,
    "offsetLabel": "refundGas",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "inB": "1",
    "setA": 1,
-   "line": 422,
+   "line": 432,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "inGAS": "1",
    "inA": "1",
    "setGAS": 1,
-   "line": 425,
+   "line": 435,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "inGAS": "1",
    "setA": 1,
-   "line": 426,
+   "line": 436,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -10881,85 +10943,9 @@
    "offset": 6,
    "mOp": 1,
    "mWR": 0,
-   "line": 427,
+   "line": 437,
    "offsetLabel": "txGasPrice",
    "useCTX": 1,
-   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
-  },
-  {
-   "inA": "1",
-   "offset": 37,
-   "mOp": 1,
-   "mWR": 1,
-   "line": 429,
-   "offsetLabel": "arithA",
-   "useCTX": 0,
-   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
-  },
-  {
-   "inB": "1",
-   "offset": 38,
-   "mOp": 1,
-   "mWR": 1,
-   "line": 430,
-   "offsetLabel": "arithB",
-   "useCTX": 0,
-   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
-  },
-  {
-   "CONST": "925",
-   "setRR": 1,
-   "JMP": 1,
-   "JMPC": 0,
-   "JMPN": 0,
-   "offset": 1258,
-   "line": 431,
-   "offsetLabel": "mulARITH",
-   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
-  },
-  {
-   "freeInTag": {
-    "op": ""
-   },
-   "inFREE": "1",
-   "setD": 1,
-   "offset": 39,
-   "mOp": 1,
-   "mWR": 0,
-   "line": 432,
-   "offsetLabel": "arithRes1",
-   "useCTX": 0,
-   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
-  },
-  {
-   "freeInTag": {
-    "op": ""
-   },
-   "inFREE": "1",
-   "setA": 1,
-   "offset": 15,
-   "mOp": 1,
-   "mWR": 0,
-   "line": 434,
-   "offsetLabel": "txSrcOriginAddr",
-   "useCTX": 1,
-   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
-  },
-  {
-   "CONST": "0",
-   "setB": 1,
-   "setC": 1,
-   "line": 435,
-   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
-  },
-  {
-   "freeInTag": {
-    "op": ""
-   },
-   "inFREE": "1",
-   "setA": 1,
-   "sRD": 1,
-   "line": 436,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -10973,7 +10959,7 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
-   "inD": "1",
+   "inB": "1",
    "offset": 38,
    "mOp": 1,
    "mWR": 1,
@@ -10983,14 +10969,14 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
-   "CONST": "932",
+   "CONST": "931",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1240,
+   "offset": 1264,
    "line": 441,
-   "offsetLabel": "addARITH",
+   "offsetLabel": "mulARITH",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -11033,128 +11019,17 @@
     "op": ""
    },
    "inFREE": "1",
-   "setSR": 1,
-   "sWR": 1,
+   "setA": 1,
+   "sRD": 1,
    "line": 446,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
-   "freeInTag": {
-    "op": ""
-   },
-   "inFREE": "1",
-   "setA": 1,
-   "offset": 0,
-   "mOp": 1,
-   "mWR": 0,
-   "line": 452,
-   "offsetLabel": "txGas",
-   "useCTX": 1,
-   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
-  },
-  {
-   "inA": "1",
-   "inGAS": "-1",
-   "setA": 1,
-   "line": 453,
-   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
-  },
-  {
-   "freeInTag": {
-    "op": ""
-   },
-   "inFREE": "1",
-   "setB": 1,
-   "offset": 6,
-   "mOp": 1,
-   "mWR": 0,
-   "line": 455,
-   "offsetLabel": "txGasPrice",
-   "useCTX": 1,
-   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
-  },
-  {
    "inA": "1",
    "offset": 37,
    "mOp": 1,
    "mWR": 1,
-   "line": 457,
-   "offsetLabel": "arithA",
-   "useCTX": 0,
-   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
-  },
-  {
-   "inB": "1",
-   "offset": 38,
-   "mOp": 1,
-   "mWR": 1,
-   "line": 458,
-   "offsetLabel": "arithB",
-   "useCTX": 0,
-   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
-  },
-  {
-   "CONST": "942",
-   "setRR": 1,
-   "JMP": 1,
-   "JMPC": 0,
-   "JMPN": 0,
-   "offset": 1258,
-   "line": 459,
-   "offsetLabel": "mulARITH",
-   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
-  },
-  {
-   "freeInTag": {
-    "op": ""
-   },
-   "inFREE": "1",
-   "setD": 1,
-   "offset": 39,
-   "mOp": 1,
-   "mWR": 0,
-   "line": 460,
-   "offsetLabel": "arithRes1",
-   "useCTX": 0,
-   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
-  },
-  {
-   "freeInTag": {
-    "op": ""
-   },
-   "inFREE": "1",
-   "setA": 1,
-   "offset": 7,
-   "mOp": 1,
-   "mWR": 0,
-   "line": 462,
-   "offsetLabel": "sequencerAddr",
-   "useCTX": 0,
-   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
-  },
-  {
-   "CONST": "0",
-   "setB": 1,
-   "setC": 1,
-   "line": 463,
-   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
-  },
-  {
-   "freeInTag": {
-    "op": ""
-   },
-   "inFREE": "1",
-   "setA": 1,
-   "sRD": 1,
-   "line": 464,
-   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
-  },
-  {
-   "inA": "1",
-   "offset": 37,
-   "mOp": 1,
-   "mWR": 1,
-   "line": 466,
+   "line": 449,
    "offsetLabel": "arithA",
    "useCTX": 0,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -11164,19 +11039,19 @@
    "offset": 38,
    "mOp": 1,
    "mWR": 1,
-   "line": 467,
+   "line": 450,
    "offsetLabel": "arithB",
    "useCTX": 0,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
-   "CONST": "949",
+   "CONST": "938",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1240,
-   "line": 468,
+   "offset": 1246,
+   "line": 451,
    "offsetLabel": "addARITH",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
@@ -11189,7 +11064,118 @@
    "offset": 39,
    "mOp": 1,
    "mWR": 0,
+   "line": 452,
+   "offsetLabel": "arithRes1",
+   "useCTX": 0,
+   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
+  },
+  {
+   "freeInTag": {
+    "op": ""
+   },
+   "inFREE": "1",
+   "setA": 1,
+   "offset": 15,
+   "mOp": 1,
+   "mWR": 0,
+   "line": 454,
+   "offsetLabel": "txSrcOriginAddr",
+   "useCTX": 1,
+   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
+  },
+  {
+   "CONST": "0",
+   "setB": 1,
+   "setC": 1,
+   "line": 455,
+   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
+  },
+  {
+   "freeInTag": {
+    "op": ""
+   },
+   "inFREE": "1",
+   "setSR": 1,
+   "sWR": 1,
+   "line": 456,
+   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
+  },
+  {
+   "freeInTag": {
+    "op": ""
+   },
+   "inFREE": "1",
+   "setA": 1,
+   "offset": 0,
+   "mOp": 1,
+   "mWR": 0,
+   "line": 462,
+   "offsetLabel": "txGas",
+   "useCTX": 1,
+   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
+  },
+  {
+   "inA": "1",
+   "inGAS": "-1",
+   "setA": 1,
+   "line": 463,
+   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
+  },
+  {
+   "freeInTag": {
+    "op": ""
+   },
+   "inFREE": "1",
+   "setB": 1,
+   "offset": 6,
+   "mOp": 1,
+   "mWR": 0,
+   "line": 465,
+   "offsetLabel": "txGasPrice",
+   "useCTX": 1,
+   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
+  },
+  {
+   "inA": "1",
+   "offset": 37,
+   "mOp": 1,
+   "mWR": 1,
+   "line": 467,
+   "offsetLabel": "arithA",
+   "useCTX": 0,
+   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
+  },
+  {
+   "inB": "1",
+   "offset": 38,
+   "mOp": 1,
+   "mWR": 1,
+   "line": 468,
+   "offsetLabel": "arithB",
+   "useCTX": 0,
+   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
+  },
+  {
+   "CONST": "948",
+   "setRR": 1,
+   "JMP": 1,
+   "JMPC": 0,
+   "JMPN": 0,
+   "offset": 1264,
    "line": 469,
+   "offsetLabel": "mulARITH",
+   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
+  },
+  {
+   "freeInTag": {
+    "op": ""
+   },
+   "inFREE": "1",
+   "setD": 1,
+   "offset": 39,
+   "mOp": 1,
+   "mWR": 0,
+   "line": 470,
    "offsetLabel": "arithRes1",
    "useCTX": 0,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -11203,7 +11189,7 @@
    "offset": 7,
    "mOp": 1,
    "mWR": 0,
-   "line": 470,
+   "line": 472,
    "offsetLabel": "sequencerAddr",
    "useCTX": 0,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -11212,7 +11198,83 @@
    "CONST": "0",
    "setB": 1,
    "setC": 1,
-   "line": 471,
+   "line": 473,
+   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
+  },
+  {
+   "freeInTag": {
+    "op": ""
+   },
+   "inFREE": "1",
+   "setA": 1,
+   "sRD": 1,
+   "line": 474,
+   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
+  },
+  {
+   "inA": "1",
+   "offset": 37,
+   "mOp": 1,
+   "mWR": 1,
+   "line": 476,
+   "offsetLabel": "arithA",
+   "useCTX": 0,
+   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
+  },
+  {
+   "inD": "1",
+   "offset": 38,
+   "mOp": 1,
+   "mWR": 1,
+   "line": 477,
+   "offsetLabel": "arithB",
+   "useCTX": 0,
+   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
+  },
+  {
+   "CONST": "955",
+   "setRR": 1,
+   "JMP": 1,
+   "JMPC": 0,
+   "JMPN": 0,
+   "offset": 1246,
+   "line": 478,
+   "offsetLabel": "addARITH",
+   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
+  },
+  {
+   "freeInTag": {
+    "op": ""
+   },
+   "inFREE": "1",
+   "setD": 1,
+   "offset": 39,
+   "mOp": 1,
+   "mWR": 0,
+   "line": 479,
+   "offsetLabel": "arithRes1",
+   "useCTX": 0,
+   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
+  },
+  {
+   "freeInTag": {
+    "op": ""
+   },
+   "inFREE": "1",
+   "setA": 1,
+   "offset": 7,
+   "mOp": 1,
+   "mWR": 0,
+   "line": 480,
+   "offsetLabel": "sequencerAddr",
+   "useCTX": 0,
+   "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
+  },
+  {
+   "CONST": "0",
+   "setB": 1,
+   "setC": 1,
+   "line": 481,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -11222,7 +11284,7 @@
    "inFREE": "1",
    "setSR": 1,
    "sWR": 1,
-   "line": 472,
+   "line": 482,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
@@ -11234,7 +11296,7 @@
    "offset": 22,
    "mOp": 1,
    "mWR": 0,
-   "line": 477,
+   "line": 487,
    "offsetLabel": "oldHashPos",
    "useCTX": 0,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -11244,7 +11306,7 @@
    "JMPC": 0,
    "JMPN": 0,
    "offset": 66,
-   "line": 478,
+   "line": 488,
    "offsetLabel": "processTxEnd",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
@@ -11257,7 +11319,7 @@
    "offset": 29,
    "mOp": 1,
    "mWR": 0,
-   "line": 481,
+   "line": 491,
    "offsetLabel": "originCTX",
    "useCTX": 1,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -11267,8 +11329,8 @@
    "inA": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 959,
-   "line": 482,
+   "offset": 965,
+   "line": 492,
    "offsetLabel": "invalidTxOrigin",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
@@ -11281,7 +11343,7 @@
    "offset": 20,
    "mOp": 1,
    "mWR": 0,
-   "line": 483,
+   "line": 493,
    "offsetLabel": "initSR",
    "useCTX": 1,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
@@ -11290,23 +11352,23 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 953,
-   "line": 485,
+   "offset": 959,
+   "line": 495,
    "offsetLabel": "terminateTX",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "inA": "1",
    "setCTX": 1,
-   "line": 488,
+   "line": 498,
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
   {
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 955,
-   "line": 489,
+   "offset": 961,
+   "line": 499,
    "offsetLabel": "invalidTx",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/process_tx.zkasm"
   },
@@ -11332,7 +11394,7 @@
    "CONST": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 970,
+   "offset": 976,
    "line": 21,
    "offsetLabel": "endca2",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/utils.zkasm"
@@ -11341,7 +11403,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 965,
+   "offset": 971,
    "line": 22,
    "offsetLabel": "ca2",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/utils.zkasm"
@@ -11480,7 +11542,7 @@
    "inFREE": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 993,
+   "offset": 999,
    "line": 43,
    "offsetLabel": "copyInit2",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/utils.zkasm"
@@ -11490,7 +11552,7 @@
    "CONST": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 1031,
+   "offset": 1037,
    "line": 46,
    "offsetLabel": "copyEnd",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/utils.zkasm"
@@ -11500,7 +11562,7 @@
    "CONST": "-32",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 986,
+   "offset": 992,
    "line": 47,
    "offsetLabel": "copyFinal",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/utils.zkasm"
@@ -11586,7 +11648,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 977,
+   "offset": 983,
    "line": 54,
    "offsetLabel": "copyInit",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/utils.zkasm"
@@ -11707,7 +11769,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1031,
+   "offset": 1037,
    "line": 63,
    "offsetLabel": "copyEnd",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/utils.zkasm"
@@ -11717,7 +11779,7 @@
    "CONST": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 1031,
+   "offset": 1037,
    "line": 66,
    "offsetLabel": "copyEnd",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/utils.zkasm"
@@ -11727,7 +11789,7 @@
    "CONST": "-32",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 1008,
+   "offset": 1014,
    "line": 67,
    "offsetLabel": "copyFinal2",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/utils.zkasm"
@@ -11944,7 +12006,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 993,
+   "offset": 999,
    "line": 80,
    "offsetLabel": "copyInit2",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/utils.zkasm"
@@ -11969,7 +12031,7 @@
    "setD": 1,
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 1018,
+   "offset": 1024,
    "line": 83,
    "offsetLabel": "copyFinal22",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/utils.zkasm"
@@ -12137,7 +12199,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1031,
+   "offset": 1037,
    "line": 92,
    "offsetLabel": "copyEnd",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/utils.zkasm"
@@ -12450,7 +12512,7 @@
    "inB": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 1044,
+   "offset": 1050,
    "line": 125,
    "offsetLabel": "getLenEnd",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/utils.zkasm"
@@ -12500,7 +12562,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1037,
+   "offset": 1043,
    "line": 129,
    "offsetLabel": "getLenBytesLoop",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/utils.zkasm"
@@ -12617,7 +12679,7 @@
    "CONST": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 1078,
+   "offset": 1084,
    "line": 150,
    "offsetLabel": "MSTORE322",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/utils.zkasm"
@@ -13009,7 +13071,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1118,
+   "offset": 1124,
    "line": 174,
    "offsetLabel": "MSTOREend",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/utils.zkasm"
@@ -13055,7 +13117,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1118,
+   "offset": 1124,
    "line": 180,
    "offsetLabel": "MSTOREend",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/utils.zkasm"
@@ -13129,7 +13191,7 @@
    "inC": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 1100,
+   "offset": 1106,
    "line": 194,
    "offsetLabel": "MSTOREX2",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/utils.zkasm"
@@ -13348,7 +13410,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1118,
+   "offset": 1124,
    "line": 206,
    "offsetLabel": "MSTOREend",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/utils.zkasm"
@@ -13842,7 +13904,7 @@
    "CONST": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 1150,
+   "offset": 1156,
    "line": 252,
    "offsetLabel": "MLOAD322",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/utils.zkasm"
@@ -14083,7 +14145,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1182,
+   "offset": 1188,
    "line": 275,
    "offsetLabel": "MLOADend",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/utils.zkasm"
@@ -14119,7 +14181,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1182,
+   "offset": 1188,
    "line": 280,
    "offsetLabel": "MLOADend",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/utils.zkasm"
@@ -14184,7 +14246,7 @@
    "setD": 1,
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 1168,
+   "offset": 1174,
    "line": 293,
    "offsetLabel": "MLOADX2",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/utils.zkasm"
@@ -14365,7 +14427,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1182,
+   "offset": 1188,
    "line": 303,
    "offsetLabel": "MLOADend",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/utils.zkasm"
@@ -14725,7 +14787,7 @@
    "CONST": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 1209,
+   "offset": 1215,
    "line": 341,
    "offsetLabel": "ISEMPTYSet0",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/utils.zkasm"
@@ -14774,7 +14836,7 @@
    "CONST": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 1209,
+   "offset": 1215,
    "line": 349,
    "offsetLabel": "ISEMPTYSet0",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/utils.zkasm"
@@ -14823,7 +14885,7 @@
    "CONST": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 1209,
+   "offset": 1215,
    "line": 357,
    "offsetLabel": "ISEMPTYSet0",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/utils.zkasm"
@@ -14838,7 +14900,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1211,
+   "offset": 1217,
    "line": 361,
    "offsetLabel": "ISEMPTYEnd",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/utils.zkasm"
@@ -14853,7 +14915,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1211,
+   "offset": 1217,
    "line": 365,
    "offsetLabel": "ISEMPTYEnd",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/utils.zkasm"
@@ -15014,7 +15076,7 @@
    "inD": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 1225,
+   "offset": 1231,
    "line": 387,
    "offsetLabel": "computeGasSendCallEnd",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/utils.zkasm"
@@ -15286,12 +15348,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/utils.zkasm"
   },
   {
-   "CONST": "1242",
+   "CONST": "1248",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1288,
+   "offset": 1294,
    "line": 413,
    "offsetLabel": "storeTmp",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/utils.zkasm"
@@ -15346,12 +15408,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/utils.zkasm"
   },
   {
-   "CONST": "1247",
+   "CONST": "1253",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1282,
+   "offset": 1288,
    "line": 421,
    "offsetLabel": "loadTmp",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/utils.zkasm"
@@ -15391,12 +15453,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/utils.zkasm"
   },
   {
-   "CONST": "1251",
+   "CONST": "1257",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1288,
+   "offset": 1294,
    "line": 428,
    "offsetLabel": "storeTmp",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/utils.zkasm"
@@ -15451,12 +15513,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/utils.zkasm"
   },
   {
-   "CONST": "1256",
+   "CONST": "1262",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1282,
+   "offset": 1288,
    "line": 436,
    "offsetLabel": "loadTmp",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/utils.zkasm"
@@ -15496,12 +15558,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/utils.zkasm"
   },
   {
-   "CONST": "1260",
+   "CONST": "1266",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1288,
+   "offset": 1294,
    "line": 443,
    "offsetLabel": "storeTmp",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/utils.zkasm"
@@ -15578,12 +15640,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/utils.zkasm"
   },
   {
-   "CONST": "1267",
+   "CONST": "1273",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1282,
+   "offset": 1288,
    "line": 453,
    "offsetLabel": "loadTmp",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/utils.zkasm"
@@ -15623,12 +15685,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/utils.zkasm"
   },
   {
-   "CONST": "1271",
+   "CONST": "1277",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1288,
+   "offset": 1294,
    "line": 460,
    "offsetLabel": "storeTmp",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/utils.zkasm"
@@ -15733,12 +15795,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/utils.zkasm"
   },
   {
-   "CONST": "1280",
+   "CONST": "1286",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1282,
+   "offset": 1288,
    "line": 472,
    "offsetLabel": "loadTmp",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/utils.zkasm"
@@ -15926,7 +15988,7 @@
    "CONST": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 1303,
+   "offset": 1309,
    "line": 7,
    "offsetLabel": "opSTOPend",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -16005,7 +16067,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 14,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -16014,7 +16076,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 867,
+   "offset": 873,
    "line": 17,
    "offsetLabel": "endCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -16087,12 +16149,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1310",
+   "CONST": "1316",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1240,
+   "offset": 1246,
    "line": 27,
    "offsetLabel": "addARITH",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -16137,7 +16199,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 31,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -16210,12 +16272,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1320",
+   "CONST": "1326",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1258,
+   "offset": 1264,
    "line": 40,
    "offsetLabel": "mulARITH",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -16260,7 +16322,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 44,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -16333,12 +16395,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1330",
+   "CONST": "1336",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1249,
+   "offset": 1255,
    "line": 53,
    "offsetLabel": "subARITH",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -16383,7 +16445,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 57,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -16456,12 +16518,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1340",
+   "CONST": "1346",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1269,
+   "offset": 1275,
    "line": 66,
    "offsetLabel": "divARITH",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -16506,7 +16568,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 70,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -16539,12 +16601,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1347",
+   "CONST": "1353",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 961,
+   "offset": 967,
    "line": 75,
    "offsetLabel": "abs",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -16582,12 +16644,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1351",
+   "CONST": "1357",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 961,
+   "offset": 967,
    "line": 79,
    "offsetLabel": "abs",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -16655,7 +16717,7 @@
    "CONST": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 1365,
+   "offset": 1371,
    "line": 86,
    "offsetLabel": "opSDIVNeg",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -16681,12 +16743,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1361",
+   "CONST": "1367",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1269,
+   "offset": 1275,
    "line": 90,
    "offsetLabel": "divARITH",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -16731,7 +16793,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 94,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -16757,12 +16819,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1368",
+   "CONST": "1374",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1269,
+   "offset": 1275,
    "line": 100,
    "offsetLabel": "divARITH",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -16782,12 +16844,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1370",
+   "CONST": "1376",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 965,
+   "offset": 971,
    "line": 103,
    "offsetLabel": "ca2",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -16818,7 +16880,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 106,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -16891,12 +16953,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1379",
+   "CONST": "1385",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1269,
+   "offset": 1275,
    "line": 115,
    "offsetLabel": "divARITH",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -16941,7 +17003,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 119,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -16974,12 +17036,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1386",
+   "CONST": "1392",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 961,
+   "offset": 967,
    "line": 124,
    "offsetLabel": "abs",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -17017,12 +17079,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1390",
+   "CONST": "1396",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 961,
+   "offset": 967,
    "line": 128,
    "offsetLabel": "abs",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -17079,7 +17141,7 @@
    "CONST": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 1403,
+   "offset": 1409,
    "line": 134,
    "offsetLabel": "opSMODNeg",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -17105,12 +17167,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1399",
+   "CONST": "1405",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1269,
+   "offset": 1275,
    "line": 138,
    "offsetLabel": "divARITH",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -17155,7 +17217,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 142,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -17181,12 +17243,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1406",
+   "CONST": "1412",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1269,
+   "offset": 1275,
    "line": 148,
    "offsetLabel": "divARITH",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -17206,12 +17268,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1408",
+   "CONST": "1414",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 965,
+   "offset": 971,
    "line": 150,
    "offsetLabel": "ca2",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -17242,7 +17304,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 153,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -17315,12 +17377,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1417",
+   "CONST": "1423",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1240,
+   "offset": 1246,
    "line": 162,
    "offsetLabel": "addARITH",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -17380,12 +17442,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1422",
+   "CONST": "1428",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1269,
+   "offset": 1275,
    "line": 168,
    "offsetLabel": "divARITH",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -17430,7 +17492,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 172,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -17503,12 +17565,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1432",
+   "CONST": "1438",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1258,
+   "offset": 1264,
    "line": 181,
    "offsetLabel": "mulARITH",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -17568,12 +17630,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1437",
+   "CONST": "1443",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1269,
+   "offset": 1275,
    "line": 187,
    "offsetLabel": "divARITH",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -17618,7 +17680,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 191,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -17706,12 +17768,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1447",
+   "CONST": "1453",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1033,
+   "offset": 1039,
    "line": 199,
    "offsetLabel": "getLenBytes",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -17728,7 +17790,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 201,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -17802,7 +17864,7 @@
    "CONST": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 1474,
+   "offset": 1480,
    "line": 209,
    "offsetLabel": "opSIGNEXTENDEnd",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -17847,12 +17909,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1459",
+   "CONST": "1465",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1240,
+   "offset": 1246,
    "line": 214,
    "offsetLabel": "addARITH",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -17930,7 +17992,7 @@
    "CONST": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 1471,
+   "offset": 1477,
    "line": 221,
    "offsetLabel": "opSIGNEXTENDPositive",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -17974,7 +18036,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1474,
+   "offset": 1480,
    "line": 226,
    "offsetLabel": "opSIGNEXTENDEnd",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -18029,7 +18091,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 236,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -18053,7 +18115,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 241,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -18077,7 +18139,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 245,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -18160,7 +18222,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 253,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -18243,7 +18305,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 260,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -18326,7 +18388,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 268,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -18409,7 +18471,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 275,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -18492,7 +18554,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 282,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -18555,7 +18617,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 289,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -18638,7 +18700,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 297,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -18721,7 +18783,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 305,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -18804,7 +18866,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 313,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -18867,7 +18929,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 320,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -18997,7 +19059,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 332,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -19094,7 +19156,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 341,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -19191,7 +19253,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 350,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -19244,12 +19306,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1568",
+   "CONST": "1574",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1269,
+   "offset": 1275,
    "line": 360,
    "offsetLabel": "divARITH",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -19366,12 +19428,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1577",
+   "CONST": "1583",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 961,
+   "offset": 967,
    "line": 369,
    "offsetLabel": "abs",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -19432,7 +19494,7 @@
    "CONST": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 1585,
+   "offset": 1591,
    "line": 375,
    "offsetLabel": "opSARNeg",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -19463,7 +19525,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 378,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -19512,12 +19574,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1591",
+   "CONST": "1597",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1240,
+   "offset": 1246,
    "line": 387,
    "offsetLabel": "addARITH",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -19537,12 +19599,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1593",
+   "CONST": "1599",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 965,
+   "offset": 971,
    "line": 390,
    "offsetLabel": "ca2",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -19573,7 +19635,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 393,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -19671,12 +19733,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1605",
+   "CONST": "1611",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1269,
+   "offset": 1275,
    "line": 408,
    "offsetLabel": "divARITH",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -19716,12 +19778,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1609",
+   "CONST": "1615",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1258,
+   "offset": 1264,
    "line": 414,
    "offsetLabel": "mulARITH",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -19790,7 +19852,7 @@
    "CONST": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 1630,
+   "offset": 1636,
    "line": 425,
    "offsetLabel": "opSHA3End",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -19800,18 +19862,18 @@
    "CONST": "-32",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 1624,
+   "offset": 1630,
    "line": 426,
    "offsetLabel": "opSHA3Final",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1618",
+   "CONST": "1624",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1123,
+   "offset": 1129,
    "line": 427,
    "offsetLabel": "MLOAD32",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -19862,18 +19924,18 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1615,
+   "offset": 1621,
    "line": 433,
    "offsetLabel": "opSHA3Loop",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1625",
+   "CONST": "1631",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1153,
+   "offset": 1159,
    "line": 435,
    "offsetLabel": "MLOADX",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -20026,7 +20088,7 @@
    "inE": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 1983,
+   "offset": 1989,
    "line": 449,
    "offsetLabel": "saveMemLength",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -20035,7 +20097,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 450,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -20059,7 +20121,7 @@
    "inA": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 1642,
+   "offset": 1648,
    "line": 455,
    "offsetLabel": "opADDRESSdeploy",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -20082,7 +20144,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1643,
+   "offset": 1649,
    "line": 457,
    "offsetLabel": "opADDRESSend",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -20127,7 +20189,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 465,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -20223,7 +20285,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 475,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -20268,7 +20330,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 481,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -20313,7 +20375,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 487,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -20358,7 +20420,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 493,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -20411,12 +20473,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1671",
+   "CONST": "1677",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1269,
+   "offset": 1275,
    "line": 502,
    "offsetLabel": "divARITH",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -20454,7 +20516,7 @@
    "inA": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 1681,
+   "offset": 1687,
    "line": 505,
    "offsetLabel": "opCALLDATALOAD2",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -20524,7 +20586,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 512,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -20683,7 +20745,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 526,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -20728,7 +20790,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 532,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -20870,7 +20932,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1706,
+   "offset": 1712,
    "line": 544,
    "offsetLabel": "opCALLDATACOPYinit",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -20880,7 +20942,7 @@
    "CONST": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 1753,
+   "offset": 1759,
    "line": 547,
    "offsetLabel": "opCALLDATACOPYend",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -20890,7 +20952,7 @@
    "CONST": "-32",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 1729,
+   "offset": 1735,
    "line": 548,
    "offsetLabel": "opCALLDATACOPYfinal",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -20916,12 +20978,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1711",
+   "CONST": "1717",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1269,
+   "offset": 1275,
    "line": 551,
    "offsetLabel": "divARITH",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -21097,12 +21159,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1723",
+   "CONST": "1729",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1048,
+   "offset": 1054,
    "line": 563,
    "offsetLabel": "MSTORE32",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -21175,7 +21237,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1706,
+   "offset": 1712,
    "line": 569,
    "offsetLabel": "opCALLDATACOPYinit",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -21333,7 +21395,7 @@
    "inD": "1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 1748,
+   "offset": 1754,
    "line": 580,
    "offsetLabel": "opCALLDATACOPYxor",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -21452,12 +21514,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1747",
+   "CONST": "1753",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1082,
+   "offset": 1088,
    "line": 589,
    "offsetLabel": "MSTOREX",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -21466,7 +21528,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1753,
+   "offset": 1759,
    "line": 590,
    "offsetLabel": "opCALLDATACOPYend",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -21545,12 +21607,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1753",
+   "CONST": "1759",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1082,
+   "offset": 1088,
    "line": 597,
    "offsetLabel": "MSTOREX",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -21602,7 +21664,7 @@
    "inE": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 1983,
+   "offset": 1989,
    "line": 603,
    "offsetLabel": "saveMemLength",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -21611,7 +21673,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 604,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -21635,7 +21697,7 @@
    "inA": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 1768,
+   "offset": 1774,
    "line": 609,
    "offsetLabel": "opCODESIZEdep",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -21718,7 +21780,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 617,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -21763,7 +21825,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 623,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -21787,7 +21849,7 @@
    "inA": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 1697,
+   "offset": 1703,
    "line": 627,
    "offsetLabel": "opCALLDATACOPY",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -21956,7 +22018,7 @@
    "CONST": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 1798,
+   "offset": 1804,
    "line": 641,
    "offsetLabel": "opCODECOPYend",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -21966,7 +22028,7 @@
    "CONST": "-32",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 1793,
+   "offset": 1799,
    "line": 642,
    "offsetLabel": "opCODECOPYfinal",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -22006,12 +22068,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1790",
+   "CONST": "1796",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1048,
+   "offset": 1054,
    "line": 645,
    "offsetLabel": "MSTORE32",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -22034,7 +22096,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1785,
+   "offset": 1791,
    "line": 648,
    "offsetLabel": "opCODECOPYinit",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -22109,12 +22171,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1798",
+   "CONST": "1804",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1082,
+   "offset": 1088,
    "line": 655,
    "offsetLabel": "MSTOREX",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -22152,7 +22214,7 @@
    "inE": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 1983,
+   "offset": 1989,
    "line": 660,
    "offsetLabel": "saveMemLength",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -22161,7 +22223,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 661,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -22206,7 +22268,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 667,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -22323,7 +22385,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 679,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -22519,7 +22581,7 @@
    "CONST": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 1841,
+   "offset": 1847,
    "line": 696,
    "offsetLabel": "opEXTCODECOPYend",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -22529,7 +22591,7 @@
    "CONST": "-32",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 1836,
+   "offset": 1842,
    "line": 697,
    "offsetLabel": "opEXTCODECOPYfinal",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -22569,12 +22631,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1833",
+   "CONST": "1839",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1048,
+   "offset": 1054,
    "line": 700,
    "offsetLabel": "MSTORE32",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -22597,7 +22659,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1828,
+   "offset": 1834,
    "line": 703,
    "offsetLabel": "opEXTCODECOPYinit",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -22672,12 +22734,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1841",
+   "CONST": "1847",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1082,
+   "offset": 1088,
    "line": 710,
    "offsetLabel": "MSTOREX",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -22715,7 +22777,7 @@
    "inE": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 1983,
+   "offset": 1989,
    "line": 715,
    "offsetLabel": "saveMemLength",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -22724,7 +22786,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 716,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -22769,7 +22831,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 723,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -22897,12 +22959,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1860",
+   "CONST": "1866",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1269,
+   "offset": 1275,
    "line": 741,
    "offsetLabel": "divARITH",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -22942,12 +23004,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1864",
+   "CONST": "1870",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1258,
+   "offset": 1264,
    "line": 747,
    "offsetLabel": "mulARITH",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -22989,7 +23051,7 @@
    "CONST": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 1884,
+   "offset": 1890,
    "line": 753,
    "offsetLabel": "opRETURNDATACOPYend",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -22999,7 +23061,7 @@
    "CONST": "-32",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 1878,
+   "offset": 1884,
    "line": 754,
    "offsetLabel": "opRETURNDATACOPYfinal",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -23011,12 +23073,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1871",
+   "CONST": "1877",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1123,
+   "offset": 1129,
    "line": 756,
    "offsetLabel": "MLOAD32",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -23044,12 +23106,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1875",
+   "CONST": "1881",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1048,
+   "offset": 1054,
    "line": 760,
    "offsetLabel": "MSTORE32",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -23071,7 +23133,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1867,
+   "offset": 1873,
    "line": 763,
    "offsetLabel": "opRETURNDATACOPYinit",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -23083,12 +23145,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1880",
+   "CONST": "1886",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1153,
+   "offset": 1159,
    "line": 767,
    "offsetLabel": "MLOADX",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -23116,12 +23178,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1884",
+   "CONST": "1890",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1082,
+   "offset": 1088,
    "line": 771,
    "offsetLabel": "MSTOREX",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -23159,7 +23221,7 @@
    "inE": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 1983,
+   "offset": 1989,
    "line": 776,
    "offsetLabel": "saveMemLength",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -23168,7 +23230,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 777,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -23324,7 +23386,7 @@
    "CONST": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 1909,
+   "offset": 1915,
    "line": 796,
    "offsetLabel": "opEXTCODEHASHend",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -23334,7 +23396,7 @@
    "CONST": "-32",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 1906,
+   "offset": 1912,
    "line": 797,
    "offsetLabel": "opEXTCODEHASHfinal",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -23407,7 +23469,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1899,
+   "offset": 1905,
    "line": 802,
    "offsetLabel": "opEXTCODEHASHinit",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -23492,7 +23554,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 813,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -23551,7 +23613,7 @@
    "CONST": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 1931,
+   "offset": 1937,
    "line": 822,
    "offsetLabel": "opBLOCKHASHzero",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -23683,7 +23745,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 842,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -23707,7 +23769,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 847,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -23752,7 +23814,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 853,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -23797,7 +23859,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 860,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -23842,7 +23904,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 866,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -23887,7 +23949,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 872,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -23932,7 +23994,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 878,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -23977,7 +24039,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 884,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -24039,7 +24101,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 893,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -24062,7 +24124,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 898,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -24095,12 +24157,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1969",
+   "CONST": "1975",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1123,
+   "offset": 1129,
    "line": 903,
    "offsetLabel": "MLOAD32",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -24146,7 +24208,7 @@
    "inE": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 1983,
+   "offset": 1989,
    "line": 907,
    "offsetLabel": "saveMemLength",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -24155,7 +24217,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 908,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -24218,12 +24280,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1979",
+   "CONST": "1985",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1048,
+   "offset": 1054,
    "line": 915,
    "offsetLabel": "MSTORE32",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -24254,7 +24316,7 @@
    "inE": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 1983,
+   "offset": 1989,
    "line": 918,
    "offsetLabel": "saveMemLength",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -24263,18 +24325,18 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 919,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1984",
+   "CONST": "1990",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1230,
+   "offset": 1236,
    "line": 923,
    "offsetLabel": "saveMem",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -24283,7 +24345,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 924,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -24387,12 +24449,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "1993",
+   "CONST": "1999",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1082,
+   "offset": 1088,
    "line": 934,
    "offsetLabel": "MSTOREX",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -24423,7 +24485,7 @@
    "inE": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 1983,
+   "offset": 1989,
    "line": 937,
    "offsetLabel": "saveMemLength",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -24432,7 +24494,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 938,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -24545,7 +24607,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 949,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -24569,7 +24631,7 @@
    "inA": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 3053,
+   "offset": 3059,
    "line": 953,
    "offsetLabel": "invalidStaticTx",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -24650,7 +24712,7 @@
    "inA": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2016,
+   "offset": 2022,
    "line": 959,
    "offsetLabel": "deploymentSSTORE",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -24673,7 +24735,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 2017,
+   "offset": 2023,
    "line": 961,
    "offsetLabel": "opSSTOREinit",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -24821,7 +24883,7 @@
    "CONST": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2032,
+   "offset": 2038,
    "line": 979,
    "offsetLabel": "opSSTOREdif",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -24837,7 +24899,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 2082,
+   "offset": 2088,
    "line": 982,
    "offsetLabel": "opSSTOREend",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -24870,7 +24932,7 @@
    "CONST": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2042,
+   "offset": 2048,
    "line": 989,
    "offsetLabel": "opSSTOREdifA",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -24903,7 +24965,7 @@
    "CONST": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2074,
+   "offset": 2080,
    "line": 994,
    "offsetLabel": "opSSTOREdifB",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -24919,7 +24981,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 2082,
+   "offset": 2088,
    "line": 997,
    "offsetLabel": "opSSTOREend",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -24959,7 +25021,7 @@
    "CONST": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2057,
+   "offset": 2063,
    "line": 1005,
    "offsetLabel": "opSSTOREdifA1",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -24992,7 +25054,7 @@
    "CONST": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2082,
+   "offset": 2088,
    "line": 1013,
    "offsetLabel": "opSSTOREend",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -25019,7 +25081,7 @@
    "CONST": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2071,
+   "offset": 2077,
    "line": 1017,
    "offsetLabel": "opSSTOREdifA2",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -25054,7 +25116,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 2082,
+   "offset": 2088,
    "line": 1021,
    "offsetLabel": "opSSTOREend",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -25087,7 +25149,7 @@
    "CONST": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2064,
+   "offset": 2070,
    "line": 1028,
    "offsetLabel": "opSSTOREdifA12",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -25122,7 +25184,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 2047,
+   "offset": 2053,
    "line": 1032,
    "offsetLabel": "opSSTOREdifAB",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -25155,7 +25217,7 @@
    "CONST": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2047,
+   "offset": 2053,
    "line": 1038,
    "offsetLabel": "opSSTOREdifAB",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -25190,7 +25252,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 2047,
+   "offset": 2053,
    "line": 1042,
    "offsetLabel": "opSSTOREdifAB",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -25225,7 +25287,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 2082,
+   "offset": 2088,
    "line": 1048,
    "offsetLabel": "opSSTOREend",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -25265,7 +25327,7 @@
    "CONST": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2082,
+   "offset": 2088,
    "line": 1056,
    "offsetLabel": "opSSTOREend",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -25300,7 +25362,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 2082,
+   "offset": 2088,
    "line": 1060,
    "offsetLabel": "opSSTOREend",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -25324,7 +25386,7 @@
    "inA": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2086,
+   "offset": 2092,
    "line": 1064,
    "offsetLabel": "mloadContract",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -25347,7 +25409,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 2087,
+   "offset": 2093,
    "line": 1066,
    "offsetLabel": "opSSTOREsr",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -25400,7 +25462,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 1075,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -25449,7 +25511,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 1083,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -25510,7 +25572,7 @@
    "CONST": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 864,
+   "offset": 870,
    "line": 1092,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -25552,7 +25614,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 1096,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -25583,7 +25645,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 1102,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -25628,7 +25690,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 1108,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -25659,7 +25721,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 1113,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -25675,7 +25737,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 1117,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -25737,7 +25799,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 1124,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -25787,12 +25849,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "2128",
+   "CONST": "2134",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1269,
+   "offset": 1275,
    "line": 1132,
    "offsetLabel": "divARITH",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -25859,7 +25921,7 @@
    "inFREE": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2139,
+   "offset": 2145,
    "line": 1136,
    "offsetLabel": "opAuxPUSHC",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -25955,7 +26017,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 1143,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -26143,7 +26205,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 1158,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -26173,7 +26235,7 @@
    "inB": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2123,
+   "offset": 2129,
    "line": 1163,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -26182,7 +26244,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 2118,
+   "offset": 2124,
    "line": 1164,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -26212,7 +26274,7 @@
    "inB": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2123,
+   "offset": 2129,
    "line": 1169,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -26221,7 +26283,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 2118,
+   "offset": 2124,
    "line": 1170,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -26251,7 +26313,7 @@
    "inB": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2123,
+   "offset": 2129,
    "line": 1175,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -26260,7 +26322,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 2118,
+   "offset": 2124,
    "line": 1176,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -26290,7 +26352,7 @@
    "inB": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2123,
+   "offset": 2129,
    "line": 1181,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -26299,7 +26361,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 2118,
+   "offset": 2124,
    "line": 1182,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -26329,7 +26391,7 @@
    "inB": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2123,
+   "offset": 2129,
    "line": 1187,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -26338,7 +26400,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 2118,
+   "offset": 2124,
    "line": 1188,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -26368,7 +26430,7 @@
    "inB": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2123,
+   "offset": 2129,
    "line": 1193,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -26377,7 +26439,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 2118,
+   "offset": 2124,
    "line": 1194,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -26407,7 +26469,7 @@
    "inB": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2123,
+   "offset": 2129,
    "line": 1199,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -26416,7 +26478,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 2118,
+   "offset": 2124,
    "line": 1200,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -26446,7 +26508,7 @@
    "inB": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2123,
+   "offset": 2129,
    "line": 1205,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -26455,7 +26517,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 2118,
+   "offset": 2124,
    "line": 1206,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -26485,7 +26547,7 @@
    "inB": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2123,
+   "offset": 2129,
    "line": 1211,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -26494,7 +26556,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 2118,
+   "offset": 2124,
    "line": 1212,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -26524,7 +26586,7 @@
    "inB": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2123,
+   "offset": 2129,
    "line": 1217,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -26533,7 +26595,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 2118,
+   "offset": 2124,
    "line": 1218,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -26563,7 +26625,7 @@
    "inB": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2123,
+   "offset": 2129,
    "line": 1223,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -26572,7 +26634,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 2118,
+   "offset": 2124,
    "line": 1224,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -26602,7 +26664,7 @@
    "inB": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2123,
+   "offset": 2129,
    "line": 1229,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -26611,7 +26673,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 2118,
+   "offset": 2124,
    "line": 1230,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -26641,7 +26703,7 @@
    "inB": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2123,
+   "offset": 2129,
    "line": 1235,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -26650,7 +26712,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 2118,
+   "offset": 2124,
    "line": 1236,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -26680,7 +26742,7 @@
    "inB": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2123,
+   "offset": 2129,
    "line": 1241,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -26689,7 +26751,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 2118,
+   "offset": 2124,
    "line": 1242,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -26719,7 +26781,7 @@
    "inB": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2123,
+   "offset": 2129,
    "line": 1247,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -26728,7 +26790,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 2118,
+   "offset": 2124,
    "line": 1248,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -26758,7 +26820,7 @@
    "inB": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2123,
+   "offset": 2129,
    "line": 1253,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -26767,7 +26829,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 2118,
+   "offset": 2124,
    "line": 1254,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -26797,7 +26859,7 @@
    "inB": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2123,
+   "offset": 2129,
    "line": 1259,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -26806,7 +26868,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 2118,
+   "offset": 2124,
    "line": 1260,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -26836,7 +26898,7 @@
    "inB": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2123,
+   "offset": 2129,
    "line": 1265,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -26845,7 +26907,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 2118,
+   "offset": 2124,
    "line": 1266,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -26875,7 +26937,7 @@
    "inB": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2123,
+   "offset": 2129,
    "line": 1271,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -26884,7 +26946,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 2118,
+   "offset": 2124,
    "line": 1272,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -26914,7 +26976,7 @@
    "inB": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2123,
+   "offset": 2129,
    "line": 1277,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -26923,7 +26985,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 2118,
+   "offset": 2124,
    "line": 1278,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -26953,7 +27015,7 @@
    "inB": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2123,
+   "offset": 2129,
    "line": 1283,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -26962,7 +27024,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 2118,
+   "offset": 2124,
    "line": 1284,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -26992,7 +27054,7 @@
    "inB": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2123,
+   "offset": 2129,
    "line": 1289,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -27001,7 +27063,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 2118,
+   "offset": 2124,
    "line": 1290,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -27031,7 +27093,7 @@
    "inB": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2123,
+   "offset": 2129,
    "line": 1295,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -27040,7 +27102,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 2118,
+   "offset": 2124,
    "line": 1296,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -27070,7 +27132,7 @@
    "inB": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2123,
+   "offset": 2129,
    "line": 1301,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -27079,7 +27141,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 2118,
+   "offset": 2124,
    "line": 1302,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -27109,7 +27171,7 @@
    "inB": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2123,
+   "offset": 2129,
    "line": 1307,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -27118,7 +27180,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 2118,
+   "offset": 2124,
    "line": 1308,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -27148,7 +27210,7 @@
    "inB": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2123,
+   "offset": 2129,
    "line": 1313,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -27157,7 +27219,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 2118,
+   "offset": 2124,
    "line": 1314,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -27187,7 +27249,7 @@
    "inB": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2123,
+   "offset": 2129,
    "line": 1319,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -27196,7 +27258,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 2118,
+   "offset": 2124,
    "line": 1320,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -27226,7 +27288,7 @@
    "inB": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2123,
+   "offset": 2129,
    "line": 1325,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -27235,7 +27297,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 2118,
+   "offset": 2124,
    "line": 1326,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -27265,7 +27327,7 @@
    "inB": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2123,
+   "offset": 2129,
    "line": 1331,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -27274,7 +27336,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 2118,
+   "offset": 2124,
    "line": 1332,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -27304,7 +27366,7 @@
    "inB": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2123,
+   "offset": 2129,
    "line": 1337,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -27313,7 +27375,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 2118,
+   "offset": 2124,
    "line": 1338,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -27343,7 +27405,7 @@
    "inB": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2123,
+   "offset": 2129,
    "line": 1343,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -27352,7 +27414,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 2118,
+   "offset": 2124,
    "line": 1344,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -27382,7 +27444,7 @@
    "inB": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2123,
+   "offset": 2129,
    "line": 1349,
    "offsetLabel": "opAuxPUSHB",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -27391,7 +27453,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 2118,
+   "offset": 2124,
    "line": 1350,
    "offsetLabel": "opAuxPUSHA",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -27448,7 +27510,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 1357,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -27513,7 +27575,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 1365,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -27578,7 +27640,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 1373,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -27643,7 +27705,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 1381,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -27708,7 +27770,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 1389,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -27773,7 +27835,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 1397,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -27838,7 +27900,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 1405,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -27903,7 +27965,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 1413,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -27968,7 +28030,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 1421,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -28033,7 +28095,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 1429,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -28098,7 +28160,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 1437,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -28163,7 +28225,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 1445,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -28228,7 +28290,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 1453,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -28293,7 +28355,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 1461,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -28358,7 +28420,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 1469,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -28423,7 +28485,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 1477,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -28516,7 +28578,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 1486,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -28624,7 +28686,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 1497,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -28732,7 +28794,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 1508,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -28840,7 +28902,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 1519,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -28948,7 +29010,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 1530,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -29056,7 +29118,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 1541,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -29164,7 +29226,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 1552,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -29272,7 +29334,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 1563,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -29380,7 +29442,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 1574,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -29488,7 +29550,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 1585,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -29596,7 +29658,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 1596,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -29704,7 +29766,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 1607,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -29812,7 +29874,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 1618,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -29920,7 +29982,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 1629,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -30028,7 +30090,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 1640,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -30136,7 +30198,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 1651,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -30160,7 +30222,7 @@
    "inA": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 3053,
+   "offset": 3059,
    "line": 1657,
    "offsetLabel": "invalidStaticTx",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -30276,7 +30338,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 2577,
+   "offset": 2583,
    "line": 1667,
    "offsetLabel": "opLOGLoop",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -30300,7 +30362,7 @@
    "inA": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 3053,
+   "offset": 3059,
    "line": 1671,
    "offsetLabel": "invalidStaticTx",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -30416,7 +30478,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 2577,
+   "offset": 2583,
    "line": 1681,
    "offsetLabel": "opLOGLoop",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -30440,7 +30502,7 @@
    "inA": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 3053,
+   "offset": 3059,
    "line": 1685,
    "offsetLabel": "invalidStaticTx",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -30556,7 +30618,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 2577,
+   "offset": 2583,
    "line": 1695,
    "offsetLabel": "opLOGLoop",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -30580,7 +30642,7 @@
    "inA": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 3053,
+   "offset": 3059,
    "line": 1699,
    "offsetLabel": "invalidStaticTx",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -30696,7 +30758,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 2577,
+   "offset": 2583,
    "line": 1709,
    "offsetLabel": "opLOGLoop",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -30720,7 +30782,7 @@
    "inA": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 3053,
+   "offset": 3059,
    "line": 1713,
    "offsetLabel": "invalidStaticTx",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -30836,7 +30898,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 2577,
+   "offset": 2583,
    "line": 1723,
    "offsetLabel": "opLOGLoop",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -30846,7 +30908,7 @@
    "CONST": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2585,
+   "offset": 2591,
    "line": 1726,
    "offsetLabel": "opSaveTopicsInit",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -30856,18 +30918,18 @@
    "CONST": "-32",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2583,
+   "offset": 2589,
    "line": 1727,
    "offsetLabel": "opLOGFinal",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "2580",
+   "CONST": "2586",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1123,
+   "offset": 1129,
    "line": 1728,
    "offsetLabel": "MLOAD32",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -30906,18 +30968,18 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 2577,
+   "offset": 2583,
    "line": 1731,
    "offsetLabel": "opLOGLoop",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "2584",
+   "CONST": "2590",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1153,
+   "offset": 1159,
    "line": 1734,
    "offsetLabel": "MLOADX",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -30964,7 +31026,7 @@
    "CONST": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2593,
+   "offset": 2599,
    "line": 1741,
    "offsetLabel": "opLOGend",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -31037,7 +31099,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 2586,
+   "offset": 2592,
    "line": 1747,
    "offsetLabel": "opSaveTopicsLoop",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -31075,7 +31137,7 @@
    "inE": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 1983,
+   "offset": 1989,
    "line": 1752,
    "offsetLabel": "saveMemLength",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -31084,7 +31146,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 1753,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -31108,7 +31170,7 @@
    "inA": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 3053,
+   "offset": 3059,
    "line": 1759,
    "offsetLabel": "invalidStaticTx",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -31347,12 +31409,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "2620",
+   "CONST": "2626",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 971,
+   "offset": 977,
    "line": 1782,
    "offsetLabel": "copySP",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -31396,12 +31458,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "2626",
+   "CONST": "2632",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1033,
+   "offset": 1039,
    "line": 1788,
    "offsetLabel": "getLenBytes",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -31468,7 +31530,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 735,
+   "offset": 743,
    "line": 1797,
    "offsetLabel": "txType",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -31599,7 +31661,7 @@
    "CONST": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2643,
+   "offset": 2649,
    "line": 1819,
    "offsetLabel": "opCALL2",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -31609,7 +31671,7 @@
    "inA": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 3053,
+   "offset": 3059,
    "line": 1820,
    "offsetLabel": "invalidStaticTx",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -31788,7 +31850,7 @@
    "CONST": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2656,
+   "offset": 2662,
    "line": 1834,
    "offsetLabel": "opCALL3",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -31824,18 +31886,18 @@
    "inB": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2660,
+   "offset": 2666,
    "line": 1840,
    "offsetLabel": "opCALL4",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "2660",
+   "CONST": "2666",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1230,
+   "offset": 1236,
    "line": 1841,
    "offsetLabel": "saveMem",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -32095,7 +32157,7 @@
    "inB": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2683,
+   "offset": 2689,
    "line": 1869,
    "offsetLabel": "opCALLend",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -32108,12 +32170,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "2684",
+   "CONST": "2690",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1216,
+   "offset": 1222,
    "line": 1876,
    "offsetLabel": "computeGasSendCall",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -32216,12 +32278,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "2693",
+   "CONST": "2699",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 971,
+   "offset": 977,
    "line": 1885,
    "offsetLabel": "copySP",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -32230,7 +32292,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 735,
+   "offset": 743,
    "line": 1886,
    "offsetLabel": "txType",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -32516,7 +32578,7 @@
    "CONST": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2715,
+   "offset": 2721,
    "line": 1910,
    "offsetLabel": "opCALLCODE2",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -32552,18 +32614,18 @@
    "inB": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2719,
+   "offset": 2725,
    "line": 1916,
    "offsetLabel": "opCALLCODE3",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "2719",
+   "CONST": "2725",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1230,
+   "offset": 1236,
    "line": 1917,
    "offsetLabel": "saveMem",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -32834,7 +32896,7 @@
    "CONST": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2742,
+   "offset": 2748,
    "line": 1943,
    "offsetLabel": "opCALLCODEend",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -32847,12 +32909,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "2743",
+   "CONST": "2749",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1216,
+   "offset": 1222,
    "line": 1949,
    "offsetLabel": "computeGasSendCall",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -32955,12 +33017,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "2752",
+   "CONST": "2758",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 971,
+   "offset": 977,
    "line": 1958,
    "offsetLabel": "copySP",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -32969,7 +33031,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 735,
+   "offset": 743,
    "line": 1959,
    "offsetLabel": "txType",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -33051,7 +33113,7 @@
    "inD": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2798,
+   "offset": 2804,
    "line": 1969,
    "offsetLabel": "opRETURNdeploy",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -33075,7 +33137,7 @@
    "CONST": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2794,
+   "offset": 2800,
    "line": 1971,
    "offsetLabel": "opRETURNend2",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -33158,7 +33220,7 @@
    "CONST": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2786,
+   "offset": 2792,
    "line": 1983,
    "offsetLabel": "opRETURNend",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -33168,18 +33230,18 @@
    "CONST": "-32",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2780,
+   "offset": 2786,
    "line": 1984,
    "offsetLabel": "opRETURNfinal",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "2770",
+   "CONST": "2776",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1123,
+   "offset": 1129,
    "line": 1985,
    "offsetLabel": "MLOAD32",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -33221,12 +33283,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "2775",
+   "CONST": "2781",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1048,
+   "offset": 1054,
    "line": 1990,
    "offsetLabel": "MSTORE32",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -33268,18 +33330,18 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 2767,
+   "offset": 2773,
    "line": 1995,
    "offsetLabel": "opRETURN32",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "2781",
+   "CONST": "2787",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1153,
+   "offset": 1159,
    "line": 1998,
    "offsetLabel": "MLOADX",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -33315,12 +33377,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "2785",
+   "CONST": "2791",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1082,
+   "offset": 1088,
    "line": 2002,
    "offsetLabel": "MSTOREX",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -33429,7 +33491,7 @@
    "inE": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 1983,
+   "offset": 1989,
    "line": 2012,
    "offsetLabel": "saveMemLength",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -33438,7 +33500,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 2013,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -33476,7 +33538,7 @@
    "inE": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 1983,
+   "offset": 1989,
    "line": 2019,
    "offsetLabel": "saveMemLength",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -33485,7 +33547,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 867,
+   "offset": 873,
    "line": 2020,
    "offsetLabel": "endCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -33516,7 +33578,7 @@
    "inB": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2802,
+   "offset": 2808,
    "line": 2026,
    "offsetLabel": "opRETURNcreate",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -33525,7 +33587,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 867,
+   "offset": 873,
    "line": 2027,
    "offsetLabel": "endCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -33703,7 +33765,7 @@
    "inA": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2849,
+   "offset": 2855,
    "line": 2053,
    "offsetLabel": "opRETURNcreateEnd",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -33774,12 +33836,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "2828",
+   "CONST": "2834",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1249,
+   "offset": 1255,
    "line": 2063,
    "offsetLabel": "subARITH",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -33837,7 +33899,7 @@
    "inB": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 955,
+   "offset": 961,
    "line": 2068,
    "offsetLabel": "invalidTx",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -33957,12 +34019,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "2845",
+   "CONST": "2851",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1240,
+   "offset": 1246,
    "line": 2083,
    "offsetLabel": "addARITH",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -34093,7 +34155,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 2097,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -34349,7 +34411,7 @@
    "CONST": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2875,
+   "offset": 2881,
    "line": 2117,
    "offsetLabel": "opDELEGATECALL2",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -34385,18 +34447,18 @@
    "inB": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2879,
+   "offset": 2885,
    "line": 2123,
    "offsetLabel": "opDELEGATECALL3",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "2879",
+   "CONST": "2885",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1230,
+   "offset": 1236,
    "line": 2124,
    "offsetLabel": "saveMem",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -34649,12 +34711,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "2900",
+   "CONST": "2906",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1216,
+   "offset": 1222,
    "line": 2149,
    "offsetLabel": "computeGasSendCall",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -34757,12 +34819,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "2909",
+   "CONST": "2915",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 971,
+   "offset": 977,
    "line": 2160,
    "offsetLabel": "copySP",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -34771,7 +34833,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 735,
+   "offset": 743,
    "line": 2163,
    "offsetLabel": "txType",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -34795,7 +34857,7 @@
    "inA": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 3053,
+   "offset": 3059,
    "line": 2169,
    "offsetLabel": "invalidStaticTx",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -35074,12 +35136,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "2936",
+   "CONST": "2942",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 971,
+   "offset": 977,
    "line": 2195,
    "offsetLabel": "copySP",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -35123,12 +35185,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "2942",
+   "CONST": "2948",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1033,
+   "offset": 1039,
    "line": 2201,
    "offsetLabel": "getLenBytes",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -35195,7 +35257,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 735,
+   "offset": 743,
    "line": 2210,
    "offsetLabel": "txType",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -35451,7 +35513,7 @@
    "CONST": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2967,
+   "offset": 2973,
    "line": 2231,
    "offsetLabel": "opSTATICCALL2",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -35487,18 +35549,18 @@
    "inB": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 2971,
+   "offset": 2977,
    "line": 2237,
    "offsetLabel": "opSTATICCALL3",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "2971",
+   "CONST": "2977",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1230,
+   "offset": 1236,
    "line": 2238,
    "offsetLabel": "saveMem",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -35733,12 +35795,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "2991",
+   "CONST": "2997",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1216,
+   "offset": 1222,
    "line": 2262,
    "offsetLabel": "computeGasSendCall",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -35841,12 +35903,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "3000",
+   "CONST": "3006",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 971,
+   "offset": 977,
    "line": 2271,
    "offsetLabel": "copySP",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -35855,7 +35917,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 735,
+   "offset": 743,
    "line": 2272,
    "offsetLabel": "txType",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -35926,7 +35988,7 @@
    "CONST": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 3013,
+   "offset": 3019,
    "line": 2283,
    "offsetLabel": "opREVERTend",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -36005,7 +36067,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 2290,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -36028,7 +36090,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 867,
+   "offset": 873,
    "line": 2294,
    "offsetLabel": "endCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -36052,7 +36114,7 @@
    "inA": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 3053,
+   "offset": 3059,
    "line": 2301,
    "offsetLabel": "invalidStaticTx",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -36183,12 +36245,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "3032",
+   "CONST": "3038",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1186,
+   "offset": 1192,
    "line": 2326,
    "offsetLabel": "ISEMPTY",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -36265,12 +36327,12 @@
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
   },
   {
-   "CONST": "3040",
+   "CONST": "3046",
    "setRR": 1,
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 1240,
+   "offset": 1246,
    "line": 2341,
    "offsetLabel": "addARITH",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -36330,7 +36392,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 867,
+   "offset": 873,
    "line": 2349,
    "offsetLabel": "endCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -36360,7 +36422,7 @@
    "CONST": "-1",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 3052,
+   "offset": 3058,
    "line": 2358,
    "offsetLabel": "opINVALIDend",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -36403,7 +36465,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 2364,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -36412,7 +36474,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 867,
+   "offset": 873,
    "line": 2367,
    "offsetLabel": "endCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -36498,7 +36560,7 @@
    "JMP": 1,
    "JMPC": 0,
    "JMPN": 0,
-   "offset": 864,
+   "offset": 870,
    "line": 2376,
    "offsetLabel": "readCode",
    "fileName": "/Users/ignasi/Documents/GitHub/hermez/prover/zkrom/main/opcodes.zkasm"
@@ -36593,287 +36655,286 @@
   "preEndLastCtx": 642,
   "selectorPrecompiled": 643,
   "processTx": 652,
-  "check_defaultChainId": 670,
-  "endCheckChainId": 674,
-  "addGas": 716,
-  "loopBytes": 720,
-  "add4Gas": 731,
-  "add16Gas": 733,
-  "txType": 735,
-  "checkTxType": 746,
-  "getContractAddress": 751,
-  "nonce1byte": 770,
-  "nonceIs0": 779,
-  "endContractAddress": 780,
-  "create2": 787,
-  "loopCreate2": 796,
-  "endloopCreate2": 803,
-  "create2end": 808,
-  "deploy": 829,
-  "readDeployBytecode": 835,
-  "callContract": 851,
-  "readByteCode": 854,
-  "readCode": 864,
-  "endCode": 867,
-  "endDeploy": 870,
-  "endByteCode": 880,
-  "moveBalances": 880,
-  "refundGas": 919,
-  "terminateTX": 953,
-  "invalidTx": 955,
-  "invalidTxOrigin": 959,
-  "abs": 961,
-  "ca2": 965,
-  "endca2": 970,
-  "copySP": 971,
-  "copyInit": 977,
-  "copyFinal": 986,
-  "copyInit2": 993,
-  "copyFinal2": 1008,
-  "copyFinal22": 1018,
-  "copyEnd": 1031,
-  "getLenBytes": 1033,
-  "getLenBytesLoop": 1037,
-  "getLenEnd": 1044,
-  "MSTORE32": 1048,
-  "MSTORE322": 1078,
-  "MSTOREX": 1082,
-  "MSTOREX2": 1100,
-  "MSTOREend": 1118,
-  "MLOAD32": 1123,
-  "MLOAD322": 1150,
-  "MLOADX": 1153,
-  "MLOADX2": 1168,
-  "MLOADend": 1182,
-  "ISEMPTY": 1186,
-  "ISEMPTYSet1": 1207,
-  "ISEMPTYSet0": 1209,
-  "ISEMPTYEnd": 1211,
-  "computeGasSendCall": 1216,
-  "computeGasSendCallEnd": 1225,
-  "saveMem": 1230,
-  "addARITH": 1240,
-  "subARITH": 1249,
-  "mulARITH": 1258,
-  "divARITH": 1269,
-  "loadTmp": 1282,
-  "storeTmp": 1288,
-  "opSTOP": 1294,
-  "opSTOPend": 1303,
-  "opADD": 1304,
-  "opMUL": 1314,
-  "opSUB": 1324,
-  "opDIV": 1334,
-  "opSDIV": 1344,
-  "opSDIVNeg": 1365,
-  "opMOD": 1373,
-  "opSMOD": 1383,
-  "opSMODNeg": 1403,
-  "opADDMOD": 1411,
-  "opMULMOD": 1426,
-  "opEXP": 1441,
-  "opSIGNEXTEND": 1449,
-  "opSIGNEXTENDPositive": 1471,
-  "opSIGNEXTENDEnd": 1474,
-  "set0": 1477,
-  "set1": 1479,
-  "opSLT": 1481,
-  "opLT": 1487,
-  "opSGT": 1493,
-  "opGT": 1499,
-  "opEQ": 1505,
-  "opISZERO": 1511,
-  "opAND": 1516,
-  "opOR": 1522,
-  "opXOR": 1528,
-  "opNOT": 1534,
-  "opBYTE": 1539,
-  "opSHR": 1549,
-  "opSHL": 1556,
-  "opSAR": 1563,
-  "opSARNeg": 1585,
-  "opSHA3": 1596,
-  "opSHA3Loop": 1615,
-  "opSHA3Final": 1624,
-  "opSHA3End": 1630,
-  "opADDRESS": 1638,
-  "opADDRESSdeploy": 1642,
-  "opADDRESSend": 1643,
-  "opBALANCE": 1646,
-  "opORIGIN": 1654,
-  "opCALLER": 1658,
-  "opCALLVALUE": 1662,
-  "opCALLDATALOAD": 1666,
-  "opCALLDATALOAD2": 1681,
-  "opCALLDATASIZE": 1693,
-  "opCALLDATACOPY": 1697,
-  "opCALLDATACOPYinit": 1706,
-  "opCALLDATACOPYfinal": 1729,
-  "opCALLDATACOPYxor": 1748,
-  "opCALLDATACOPYend": 1753,
-  "opCODESIZE": 1758,
-  "opCODESIZEdep": 1768,
-  "opCODECOPY": 1772,
-  "opCODECOPYinit": 1785,
-  "opCODECOPYfinal": 1793,
-  "opCODECOPYend": 1798,
-  "opGASPRICE": 1802,
-  "opEXTCODESIZE": 1806,
-  "opEXTCODECOPY": 1816,
-  "opEXTCODECOPYinit": 1828,
-  "opEXTCODECOPYfinal": 1836,
-  "opEXTCODECOPYend": 1841,
-  "opRETURNDATASIZE": 1845,
-  "opRETURNDATACOPY": 1849,
-  "opRETURNDATACOPYinit": 1867,
-  "opRETURNDATACOPYfinal": 1878,
-  "opRETURNDATACOPYend": 1884,
-  "opEXTCODEHASH": 1888,
-  "opEXTCODEHASHinit": 1899,
-  "opEXTCODEHASHfinal": 1906,
-  "opEXTCODEHASHend": 1909,
-  "opBLOCKHASH": 1913,
-  "opBLOCKHASHzero": 1931,
-  "opCOINBASE": 1933,
-  "opTIMESTAMP": 1937,
-  "opNUMBER": 1941,
-  "opDIFFICULTY": 1945,
-  "opGASLIMIT": 1949,
-  "opCHAINID": 1953,
-  "opSELFBALANCE": 1957,
-  "opPOP": 1963,
-  "opMLOAD": 1966,
-  "opMSTORE": 1974,
-  "saveMemLength": 1983,
-  "opMSTORE8": 1985,
-  "opSLOAD": 1997,
-  "opSSTORE": 2006,
-  "deploymentSSTORE": 2016,
-  "opSSTOREinit": 2017,
-  "opSSTOREdif": 2032,
-  "opSSTOREdifA": 2042,
-  "opSSTOREdifAB": 2047,
-  "opSSTOREdifA1": 2057,
-  "opSSTOREdifA12": 2064,
-  "opSSTOREdifA2": 2071,
-  "opSSTOREdifB": 2074,
-  "opSSTOREend": 2082,
-  "mloadContract": 2086,
-  "opSSTOREsr": 2087,
-  "opJUMP": 2091,
-  "opJUMPI": 2096,
-  "opPC": 2106,
-  "opMSIZE": 2109,
-  "opGAS": 2113,
-  "opJUMPDEST": 2116,
-  "opAuxPUSHA": 2118,
-  "opAuxPUSHB": 2123,
-  "opAuxPUSHC": 2139,
-  "opPUSH1": 2152,
-  "opPUSH2": 2156,
-  "opPUSH3": 2160,
-  "opPUSH4": 2164,
-  "opPUSH5": 2168,
-  "opPUSH6": 2172,
-  "opPUSH7": 2176,
-  "opPUSH8": 2180,
-  "opPUSH9": 2184,
-  "opPUSH10": 2188,
-  "opPUSH11": 2192,
-  "opPUSH12": 2196,
-  "opPUSH13": 2200,
-  "opPUSH14": 2204,
-  "opPUSH15": 2208,
-  "opPUSH16": 2212,
-  "opPUSH17": 2216,
-  "opPUSH18": 2220,
-  "opPUSH19": 2224,
-  "opPUSH20": 2228,
-  "opPUSH21": 2232,
-  "opPUSH22": 2236,
-  "opPUSH23": 2240,
-  "opPUSH24": 2244,
-  "opPUSH25": 2248,
-  "opPUSH26": 2252,
-  "opPUSH27": 2256,
-  "opPUSH28": 2260,
-  "opPUSH29": 2264,
-  "opPUSH30": 2268,
-  "opPUSH31": 2272,
-  "opPUSH32": 2276,
-  "opDUP1": 2280,
-  "opDUP2": 2285,
-  "opDUP3": 2291,
-  "opDUP4": 2297,
-  "opDUP5": 2303,
-  "opDUP6": 2309,
-  "opDUP7": 2315,
-  "opDUP8": 2321,
-  "opDUP9": 2327,
-  "opDUP10": 2333,
-  "opDUP11": 2339,
-  "opDUP12": 2345,
-  "opDUP13": 2351,
-  "opDUP14": 2357,
-  "opDUP15": 2363,
-  "opDUP16": 2369,
-  "opSWAP1": 2375,
-  "opSWAP2": 2382,
-  "opSWAP3": 2391,
-  "opSWAP4": 2400,
-  "opSWAP5": 2409,
-  "opSWAP6": 2418,
-  "opSWAP7": 2427,
-  "opSWAP8": 2436,
-  "opSWAP9": 2445,
-  "opSWAP10": 2454,
-  "opSWAP11": 2463,
-  "opSWAP12": 2472,
-  "opSWAP13": 2481,
-  "opSWAP14": 2490,
-  "opSWAP15": 2499,
-  "opSWAP16": 2508,
-  "opLOG0": 2517,
-  "opLOG1": 2529,
-  "opLOG2": 2541,
-  "opLOG3": 2553,
-  "opLOG4": 2565,
-  "opLOGLoop": 2577,
-  "opLOGFinal": 2583,
-  "opSaveTopicsInit": 2585,
-  "opSaveTopicsLoop": 2586,
-  "opLOGend": 2593,
-  "opCREATE": 2597,
-  "opCALL": 2632,
-  "opCALL2": 2643,
-  "opCALL3": 2656,
-  "opCALL4": 2660,
-  "opCALLend": 2683,
-  "opCALLCODE": 2694,
-  "opCALLCODE2": 2715,
-  "opCALLCODE3": 2719,
-  "opCALLCODEend": 2742,
-  "opRETURN": 2753,
-  "opRETURN32": 2767,
-  "opRETURNfinal": 2780,
-  "opRETURNend": 2786,
-  "opRETURNend2": 2794,
-  "opRETURNdeploy": 2798,
-  "opRETURNcreate": 2802,
-  "opRETURNcreateEnd": 2849,
-  "opDELEGATECALL": 2856,
-  "opDELEGATECALL2": 2875,
-  "opDELEGATECALL3": 2879,
-  "opDELEGATECALLend": 2904,
-  "opCREATE2": 2910,
-  "opSTATICCALL": 2948,
-  "opSTATICCALL2": 2967,
-  "opSTATICCALL3": 2971,
-  "opREVERT": 3001,
-  "opREVERTend": 3013,
-  "opSELFDESTRUCT": 3015,
-  "opINVALID": 3045,
-  "opINVALIDend": 3052,
-  "invalidStaticTx": 3053
+  "check_defaultChainId": 673,
+  "endCheckChainId": 677,
+  "addGas": 723,
+  "loopBytes": 727,
+  "add4Gas": 738,
+  "add16Gas": 740,
+  "txType": 743,
+  "getContractAddress": 757,
+  "nonce1byte": 776,
+  "nonceIs0": 785,
+  "endContractAddress": 786,
+  "create2": 793,
+  "loopCreate2": 802,
+  "endloopCreate2": 809,
+  "create2end": 814,
+  "deploy": 835,
+  "readDeployBytecode": 841,
+  "callContract": 857,
+  "readByteCode": 860,
+  "readCode": 870,
+  "endCode": 873,
+  "endDeploy": 876,
+  "endByteCode": 886,
+  "moveBalances": 886,
+  "refundGas": 925,
+  "terminateTX": 959,
+  "invalidTx": 961,
+  "invalidTxOrigin": 965,
+  "abs": 967,
+  "ca2": 971,
+  "endca2": 976,
+  "copySP": 977,
+  "copyInit": 983,
+  "copyFinal": 992,
+  "copyInit2": 999,
+  "copyFinal2": 1014,
+  "copyFinal22": 1024,
+  "copyEnd": 1037,
+  "getLenBytes": 1039,
+  "getLenBytesLoop": 1043,
+  "getLenEnd": 1050,
+  "MSTORE32": 1054,
+  "MSTORE322": 1084,
+  "MSTOREX": 1088,
+  "MSTOREX2": 1106,
+  "MSTOREend": 1124,
+  "MLOAD32": 1129,
+  "MLOAD322": 1156,
+  "MLOADX": 1159,
+  "MLOADX2": 1174,
+  "MLOADend": 1188,
+  "ISEMPTY": 1192,
+  "ISEMPTYSet1": 1213,
+  "ISEMPTYSet0": 1215,
+  "ISEMPTYEnd": 1217,
+  "computeGasSendCall": 1222,
+  "computeGasSendCallEnd": 1231,
+  "saveMem": 1236,
+  "addARITH": 1246,
+  "subARITH": 1255,
+  "mulARITH": 1264,
+  "divARITH": 1275,
+  "loadTmp": 1288,
+  "storeTmp": 1294,
+  "opSTOP": 1300,
+  "opSTOPend": 1309,
+  "opADD": 1310,
+  "opMUL": 1320,
+  "opSUB": 1330,
+  "opDIV": 1340,
+  "opSDIV": 1350,
+  "opSDIVNeg": 1371,
+  "opMOD": 1379,
+  "opSMOD": 1389,
+  "opSMODNeg": 1409,
+  "opADDMOD": 1417,
+  "opMULMOD": 1432,
+  "opEXP": 1447,
+  "opSIGNEXTEND": 1455,
+  "opSIGNEXTENDPositive": 1477,
+  "opSIGNEXTENDEnd": 1480,
+  "set0": 1483,
+  "set1": 1485,
+  "opSLT": 1487,
+  "opLT": 1493,
+  "opSGT": 1499,
+  "opGT": 1505,
+  "opEQ": 1511,
+  "opISZERO": 1517,
+  "opAND": 1522,
+  "opOR": 1528,
+  "opXOR": 1534,
+  "opNOT": 1540,
+  "opBYTE": 1545,
+  "opSHR": 1555,
+  "opSHL": 1562,
+  "opSAR": 1569,
+  "opSARNeg": 1591,
+  "opSHA3": 1602,
+  "opSHA3Loop": 1621,
+  "opSHA3Final": 1630,
+  "opSHA3End": 1636,
+  "opADDRESS": 1644,
+  "opADDRESSdeploy": 1648,
+  "opADDRESSend": 1649,
+  "opBALANCE": 1652,
+  "opORIGIN": 1660,
+  "opCALLER": 1664,
+  "opCALLVALUE": 1668,
+  "opCALLDATALOAD": 1672,
+  "opCALLDATALOAD2": 1687,
+  "opCALLDATASIZE": 1699,
+  "opCALLDATACOPY": 1703,
+  "opCALLDATACOPYinit": 1712,
+  "opCALLDATACOPYfinal": 1735,
+  "opCALLDATACOPYxor": 1754,
+  "opCALLDATACOPYend": 1759,
+  "opCODESIZE": 1764,
+  "opCODESIZEdep": 1774,
+  "opCODECOPY": 1778,
+  "opCODECOPYinit": 1791,
+  "opCODECOPYfinal": 1799,
+  "opCODECOPYend": 1804,
+  "opGASPRICE": 1808,
+  "opEXTCODESIZE": 1812,
+  "opEXTCODECOPY": 1822,
+  "opEXTCODECOPYinit": 1834,
+  "opEXTCODECOPYfinal": 1842,
+  "opEXTCODECOPYend": 1847,
+  "opRETURNDATASIZE": 1851,
+  "opRETURNDATACOPY": 1855,
+  "opRETURNDATACOPYinit": 1873,
+  "opRETURNDATACOPYfinal": 1884,
+  "opRETURNDATACOPYend": 1890,
+  "opEXTCODEHASH": 1894,
+  "opEXTCODEHASHinit": 1905,
+  "opEXTCODEHASHfinal": 1912,
+  "opEXTCODEHASHend": 1915,
+  "opBLOCKHASH": 1919,
+  "opBLOCKHASHzero": 1937,
+  "opCOINBASE": 1939,
+  "opTIMESTAMP": 1943,
+  "opNUMBER": 1947,
+  "opDIFFICULTY": 1951,
+  "opGASLIMIT": 1955,
+  "opCHAINID": 1959,
+  "opSELFBALANCE": 1963,
+  "opPOP": 1969,
+  "opMLOAD": 1972,
+  "opMSTORE": 1980,
+  "saveMemLength": 1989,
+  "opMSTORE8": 1991,
+  "opSLOAD": 2003,
+  "opSSTORE": 2012,
+  "deploymentSSTORE": 2022,
+  "opSSTOREinit": 2023,
+  "opSSTOREdif": 2038,
+  "opSSTOREdifA": 2048,
+  "opSSTOREdifAB": 2053,
+  "opSSTOREdifA1": 2063,
+  "opSSTOREdifA12": 2070,
+  "opSSTOREdifA2": 2077,
+  "opSSTOREdifB": 2080,
+  "opSSTOREend": 2088,
+  "mloadContract": 2092,
+  "opSSTOREsr": 2093,
+  "opJUMP": 2097,
+  "opJUMPI": 2102,
+  "opPC": 2112,
+  "opMSIZE": 2115,
+  "opGAS": 2119,
+  "opJUMPDEST": 2122,
+  "opAuxPUSHA": 2124,
+  "opAuxPUSHB": 2129,
+  "opAuxPUSHC": 2145,
+  "opPUSH1": 2158,
+  "opPUSH2": 2162,
+  "opPUSH3": 2166,
+  "opPUSH4": 2170,
+  "opPUSH5": 2174,
+  "opPUSH6": 2178,
+  "opPUSH7": 2182,
+  "opPUSH8": 2186,
+  "opPUSH9": 2190,
+  "opPUSH10": 2194,
+  "opPUSH11": 2198,
+  "opPUSH12": 2202,
+  "opPUSH13": 2206,
+  "opPUSH14": 2210,
+  "opPUSH15": 2214,
+  "opPUSH16": 2218,
+  "opPUSH17": 2222,
+  "opPUSH18": 2226,
+  "opPUSH19": 2230,
+  "opPUSH20": 2234,
+  "opPUSH21": 2238,
+  "opPUSH22": 2242,
+  "opPUSH23": 2246,
+  "opPUSH24": 2250,
+  "opPUSH25": 2254,
+  "opPUSH26": 2258,
+  "opPUSH27": 2262,
+  "opPUSH28": 2266,
+  "opPUSH29": 2270,
+  "opPUSH30": 2274,
+  "opPUSH31": 2278,
+  "opPUSH32": 2282,
+  "opDUP1": 2286,
+  "opDUP2": 2291,
+  "opDUP3": 2297,
+  "opDUP4": 2303,
+  "opDUP5": 2309,
+  "opDUP6": 2315,
+  "opDUP7": 2321,
+  "opDUP8": 2327,
+  "opDUP9": 2333,
+  "opDUP10": 2339,
+  "opDUP11": 2345,
+  "opDUP12": 2351,
+  "opDUP13": 2357,
+  "opDUP14": 2363,
+  "opDUP15": 2369,
+  "opDUP16": 2375,
+  "opSWAP1": 2381,
+  "opSWAP2": 2388,
+  "opSWAP3": 2397,
+  "opSWAP4": 2406,
+  "opSWAP5": 2415,
+  "opSWAP6": 2424,
+  "opSWAP7": 2433,
+  "opSWAP8": 2442,
+  "opSWAP9": 2451,
+  "opSWAP10": 2460,
+  "opSWAP11": 2469,
+  "opSWAP12": 2478,
+  "opSWAP13": 2487,
+  "opSWAP14": 2496,
+  "opSWAP15": 2505,
+  "opSWAP16": 2514,
+  "opLOG0": 2523,
+  "opLOG1": 2535,
+  "opLOG2": 2547,
+  "opLOG3": 2559,
+  "opLOG4": 2571,
+  "opLOGLoop": 2583,
+  "opLOGFinal": 2589,
+  "opSaveTopicsInit": 2591,
+  "opSaveTopicsLoop": 2592,
+  "opLOGend": 2599,
+  "opCREATE": 2603,
+  "opCALL": 2638,
+  "opCALL2": 2649,
+  "opCALL3": 2662,
+  "opCALL4": 2666,
+  "opCALLend": 2689,
+  "opCALLCODE": 2700,
+  "opCALLCODE2": 2721,
+  "opCALLCODE3": 2725,
+  "opCALLCODEend": 2748,
+  "opRETURN": 2759,
+  "opRETURN32": 2773,
+  "opRETURNfinal": 2786,
+  "opRETURNend": 2792,
+  "opRETURNend2": 2800,
+  "opRETURNdeploy": 2804,
+  "opRETURNcreate": 2808,
+  "opRETURNcreateEnd": 2855,
+  "opDELEGATECALL": 2862,
+  "opDELEGATECALL2": 2881,
+  "opDELEGATECALL3": 2885,
+  "opDELEGATECALLend": 2910,
+  "opCREATE2": 2916,
+  "opSTATICCALL": 2954,
+  "opSTATICCALL2": 2973,
+  "opSTATICCALL3": 2977,
+  "opREVERT": 3007,
+  "opREVERTend": 3019,
+  "opSELFDESTRUCT": 3021,
+  "opINVALID": 3051,
+  "opINVALIDend": 3058,
+  "invalidStaticTx": 3059
  }
 }

--- a/main/process_tx.zkasm
+++ b/main/process_tx.zkasm
@@ -23,16 +23,19 @@ processTx:
         $ => C                          :MLOAD(txS)
         $ => D                          :MLOAD(txV)
         $ => A                          :ECRECOVER
+        ; Check result is non-zero
+        0 => B
+        $ => B                          :EQ
+        -B                              :JMPN(invalidTx)
         A                               :MSTORE(txSrcAddr)
         A                               :MSTORE(txSrcOriginAddr)
-        ; TODO: bad signature ==> jump next txs
+
 ;;;;;;;;;
 ;; Store init state
 ;;;;;;;;;
 
         SR                              :MSTORE(initSR)
 
-; TODO: Intrinsic checks ==> jump to next transaction, maintain SR
 ;;;;;;;;
 ; Check chainID --> //TODO: chainID is defined as 64 bits which does not fit in the Field. If we consider just 63 bits it could be done directly (A - B), saving the EQ comaprison
 ;;;;;;;;
@@ -60,7 +63,7 @@ endCheckChainId:
 ; Check and update Nonce --> //TODO: same as chainID
 ;;;;;;;;
 
-        $ => A, E                       :MLOAD(txSrcOriginAddr)                                 ; Address of the origin to a and D
+        $ => A, E                       :MLOAD(txSrcOriginAddr)                                 ; Address of the origin to A and E
         1 => B                                                                                  ; Constant for nonce
         0 => C                                                                                  ; 3rd parameter does not apply to nonce
         $ => A                          :SLOAD                                                  ; Load the nonce to A and C from storage
@@ -78,15 +81,15 @@ endCheckChainId:
 ; Buy Gas
 ;;;;;;;;
 
-        $ => A                          :MLOAD(txGas)                                           ; Multiplies the txGas amd the txGasPrice
-        $ => B                          :MLOAD(txGasPrice)                                                                                ; gas*gasPrice in D
+        $ => A                          :MLOAD(txGas)                   ; Multiplies the txGas amd the txGasPrice
+        $ => B                          :MLOAD(txGasPrice)              ; gas*gasPrice in D
         ; Mul operation with Arith
         A               :MSTORE(arithA)
         B               :MSTORE(arithB)
                         :CALL(mulARITH)
         $ => D          :MLOAD(arithRes1)
 
-        $ => A                          :MLOAD(txSrcOriginAddr)
+        $ => A          :MLOAD(txSrcOriginAddr)
         0 => B,C
         $ => E                          :SLOAD                                                  ; Original Balance in E
 
@@ -94,20 +97,25 @@ endCheckChainId:
         E               :MSTORE(arithA)
         D               :MSTORE(arithB)
                         :CALL(subARITH)
-        $ => A          :MLOAD(arithRes1)
+        ; Balance - intrinsic_gas
+        $ => D          :MLOAD(arithRes1)       
+
+        $ => A          :MLOAD(txValue)
+        D               :MSTORE(arithA)
+        A               :MSTORE(arithB)
+                        :CALL(subARITH)
+        ; Balance - intrinsic_gas - value
+        $ => A          :MLOAD(arithRes1) 
 
         0 => B
         $ => B          :SLT
         -B              :JMPN(invalidTx)                                       ; If A is a negative value --> invalidTx
 
-        A => D                  
 
         $ => A                          :MLOAD(txSrcOriginAddr)
         0 => B,C
         $ => SR                         :SSTORE
 
-        ; TODO: check intrinsic --> value + gas
-        ; TODO: substract gas ==> initSR
         ; TODO: create, do not have value
 ;;;;;;;;;
 ;; Store init state
@@ -119,7 +127,6 @@ endCheckChainId:
 ;;;;;;;;
 ; Set the gas
 ;;;;;;;;
-        ; // TODO: move at the beggining
         $ => GAS                        :MLOAD(txGas)
         GAS - 21000 => GAS
 
@@ -143,7 +150,7 @@ loopBytes:
                         :CALL(mulARITH)
         $ => B          :MLOAD(arithRes1)
 
-        A - B - D - 1             :JMPN(txType)
+        A - B - D - 1                   :JMPN(txType)
         32 - D - 1                      :JMPN(addGas)
         $ => B                          :MLOAD(SP) ; TODO: mask to get byte per byte
         ${getByte(B,D)} => B
@@ -158,6 +165,12 @@ add4Gas:
 add16Gas:
         GAS - 16 => GAS
                                         :JMP(loopBytes)
+;;;;;;;;;
+;; Store init state after substracting intrinsic gas
+;;;;;;;;;
+
+        SR                              :MSTORE(initSR)
+
 txType:
 ;;;;;;;;;;
 ;;;;; Tx type
@@ -170,17 +183,14 @@ txType:
         10 => B
         $ => B                          :LT
         0 - B                           :JMPN(selectorPrecompiled) ; precompiled smart contracts
+        ; Check if destination address has bytecode to process the tx as a transaction or a call
         2 => B
         0 => C
         $ => A                          :SLOAD
-        0 => D
-
-checkTxType:
-        32 - D                          :JMPN(moveBalances)
-        ${getByte(A,D)} => B    ; // TODO: comparison with 0
-        0 - B                           :JMPN(callContract)
-        D + 1 => D
-                                        :JMP(checkTxType)
+        0 => B
+        $ => B                          :GT
+        -B                              :JMPN(callContract)
+                                        :JMP(moveBalances)
 
 getContractAddress:
         ; A new hash with position 0 is started
@@ -281,7 +291,7 @@ create2end:
         HASHPOS                         :HASHKLEN(E)
         $ => A                          :HASHKDIGEST(E)
         12 => D
-                                        :CALL(SHLarith) ; // TODO: Could be replaced by a bitwise and: ${bitwise_and(A, 2**160 - 1)
+                                        :CALL(SHLarith)
                                         :CALL(SHRarith)
         A                               :MSTORE(createContractAddress)
 


### PR DESCRIPTION
- Add check at signature verification in case ecrecover is failing
- Check balance at intrinsic checks
- Store initSR after intrinsic_gas consumption
- Improved loop at txType function using new :GT operand