### PR TITLE
Feature/remove precompiled

### DIFF
--- a/build/rom.json
+++ b/build/rom.json
@@ -10422,9 +10422,9 @@
    "CONST": "-3",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 681,
+   "offset": 1166,
    "line": 14,
-   "offsetLabel": "SHA256",
+   "offsetLabel": "moveBalances",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/precompiled/selector.zkasm"
   },
   {
@@ -10432,9 +10432,9 @@
    "CONST": "-4",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 702,
+   "offset": 1166,
    "line": 15,
-   "offsetLabel": "RIPEMD160",
+   "offsetLabel": "moveBalances",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/precompiled/selector.zkasm"
   },
   {
@@ -10462,9 +10462,9 @@
    "CONST": "-7",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 808,
+   "offset": 1166,
    "line": 18,
-   "offsetLabel": "ECADD",
+   "offsetLabel": "moveBalances",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/precompiled/selector.zkasm"
   },
   {
@@ -10472,9 +10472,9 @@
    "CONST": "-8",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 836,
+   "offset": 1166,
    "line": 19,
-   "offsetLabel": "ECMUL",
+   "offsetLabel": "moveBalances",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/precompiled/selector.zkasm"
   },
   {
@@ -10482,9 +10482,9 @@
    "CONST": "-9",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 862,
+   "offset": 1166,
    "line": 20,
-   "offsetLabel": "ECPAIRING",
+   "offsetLabel": "moveBalances",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/precompiled/selector.zkasm"
   },
   {
@@ -10492,9 +10492,9 @@
    "CONST": "-10",
    "JMPC": 0,
    "JMPN": 1,
-   "offset": 883,
+   "offset": 1166,
    "line": 21,
-   "offsetLabel": "BLAKE2F",
+   "offsetLabel": "moveBalances",
    "fileName": "/home/ixnay/iden3Dev/github/zkrom/main/precompiled/selector.zkasm"
   },
   {

--- a/main/precompiled/selector.zkasm
+++ b/main/precompiled/selector.zkasm
@@ -11,11 +11,11 @@ INCLUDE "end.zkasm"
 
 selectorPrecompiled:
     A - 2               :JMPN(funcECRECOVER)
-    A - 3               :JMPN(SHA256)
-    A - 4               :JMPN(RIPEMD160)
+    A - 3               :JMPN(moveBalances)  ;:JMPN(SHA256)
+    A - 4               :JMPN(moveBalances)  ;:JMPN(RIPEMD160)
     A - 5               :JMPN(IDENTITY)
     A - 6               :JMPN(MODEXP)
-    A - 7               :JMPN(ECADD)
-    A - 8               :JMPN(ECMUL)
-    A - 9               :JMPN(ECPAIRING)
-    A - 10              :JMPN(BLAKE2F)
+    A - 7               :JMPN(moveBalances) ;:JMPN(ECADD)
+    A - 8               :JMPN(moveBalances) ;:JMPN(ECMUL)
+    A - 9               :JMPN(moveBalances) ;:JMPN(ECPAIRING)
+    A - 10              :JMPN(moveBalances) ;:JMPN(BLAKE2F)


### PR DESCRIPTION
Please, do not merge this PR until https://github.com/hermeznetwork/zkrom/pull/69 is merged
- remove precompiled that are not used and just jump to `moveBalances` instead