### PR TITLE
Mask address from opcode inputs

### DIFF
--- a/main/opcodes.zkasm
+++ b/main/opcodes.zkasm
@@ -617,6 +617,7 @@ opBALANCE:
 
     SP - 1 => SP    :JMPN(stackUnderflow)
     $ => A          :MLOAD(SP)
+                    :CALL(maskAddress) ; Mask address to 20 bytes
     0 => B,C        ; balance smt key
     $ => D          :SLOAD
     D               :MSTORE(SP++)
@@ -896,6 +897,7 @@ opEXTCODESIZE:
 
     SP - 1 => SP    :JMPN(stackUnderflow)
     $ => A          :MLOAD(SP)
+                    :CALL(maskAddress) ; Mask address to 20 bytes
     ${touchedAddress(A)} => D
     %SMT_KEY_SC_LENGTH => B
     0 => C
@@ -921,6 +923,7 @@ opEXTCODECOPY:
     SP - 4          :JMPN(stackUnderflow)
     SP - 1 => SP
     $ => A          :MLOAD(SP--) ;addr
+                    :CALL(maskAddress) ; Mask address to 20 bytes
     ${touchedAddress(A)} => D
     GAS-100-D*2500 => GAS            :JMPN(outOfGas)
                     :CALL(opEXTCODECOPYCheckHash)
@@ -929,7 +932,7 @@ opEXTCODECOPY:
     $ => E          :MLOAD(SP)   ; bytes to read from bytecode
     D               :MSTORE(lastMemOffset)
     E               :MSTORE(lastMemLength)
-
+    
     ; Check counters
     %MAX_CNT_BINARY - CNT_BINARY - 2*E :JMPN(outOfCounters)
     %MAX_CNT_MEM_ALIGN - CNT_MEM_ALIGN - 2*E :JMPN(outOfCounters)
@@ -1123,6 +1126,7 @@ opEXTCODEHASH:
 
     SP - 1 => SP    :JMPN(stackUnderflow)
     $ => A          :MLOAD(SP)
+                    :CALL(maskAddress) ; Mask address to 20 bytes
     ${touchedAddress(A)} => D
     GAS-100-D*2500 => GAS    :JMPN(outOfGas)
     %SMT_KEY_SC_CODE => B
@@ -2404,7 +2408,6 @@ opCREATE:
 ; // https://eips.ethereum.org/EIPS/eip-211
 opCALL:
 
-
     SP - 7          :JMPN(stackUnderflow)
     SP - 1 => SP
     CTX             :MSTORE(originAuxCTX)
@@ -2413,6 +2416,7 @@ opCALL:
     A               :MSTORE(gasCall)
     ; Store address call
     $ => A          :MLOAD(SP--)
+                    :CALL(maskAddress) ; Mask address to 20 bytes
     A               :MSTORE(addrCall)
     ; Store value call
     $ => A          :MLOAD(SP--)
@@ -2512,6 +2516,7 @@ opCALLCODE: ; TODO check staticCall
     A               :MSTORE(gasCall)
     ; Store address call
     $ => A          :MLOAD(SP--)
+                    :CALL(maskAddress) ; Mask address to 20 bytes
     A               :MSTORE(addrCall)
     ; Store value call
     $ => A          :MLOAD(SP--)
@@ -2737,6 +2742,7 @@ opDELEGATECALL:
     A               :MSTORE(gasCall)
     ; Store address call
     $ => A          :MLOAD(SP--)
+                    :CALL(maskAddress) ; Mask address to 20 bytes
     A               :MSTORE(addrCall)
     ; Store bytes offset int the memory, the calldata of the subcontext
     $ => A          :MLOAD(SP--)
@@ -2883,6 +2889,7 @@ opSTATICCALL:
     $ => A          :MLOAD(SP--)
     A               :MSTORE(gasCall)
     $ => A          :MLOAD(SP--)
+                    :CALL(maskAddress) ; Mask address to 20 bytes
     A               :MSTORE(addrCall)
     $ => A          :MLOAD(SP--)
     A               :MSTORE(argsOffsetCall)
@@ -3011,7 +3018,7 @@ opREVERTend:
                     :JMP(readCode)
 
 ; // TODO: handle if depth is over 0
-; DelegateCAll + selfdestruct, should destro the caller bytecode
+; DelegateCAll + selfdestruct, should destroy the caller bytecode
 ; Test selfDestruct: sent value to another contract
 ; TODO selfdestrut should destory the contract at the end of the transaction
 opSELFDESTRUCT:
@@ -3044,10 +3051,11 @@ opSELFDESTRUCT:
 
     ; read receiver
     SP - 1 => SP        :JMPN(stackUnderflow)
-    $ => E              :MLOAD(SP)
-
+    $ => A              :MLOAD(SP)
+                        :CALL(maskAddress) ; Mask address to 20 bytes
     ; gas: check receiver is empty and balance gt 0
-    E => C
+    A => C
+    A => E
     0 => A
     D => B
     $                   :EQ,JMPC(opSELFDESTRUCT2)

--- a/main/precompiled/selector.zkasm
+++ b/main/precompiled/selector.zkasm
@@ -10,11 +10,11 @@ INCLUDE "end.zkasm"
  */
 selectorPrecompiled:
     A - 2               :JMPN(funcECRECOVER)
-    A - 3               :JMPN(handleGas)  ;:JMPN(SHA256)
-    A - 4               :JMPN(handleGas)  ;:JMPN(RIPEMD160)
+    A - 3               :JMPN(readCode)  ;:JMPN(SHA256)
+    A - 4               :JMPN(readCode)  ;:JMPN(RIPEMD160)
     A - 5               :JMPN(IDENTITY)
     A - 6               :JMPN(MODEXP)
-    A - 7               :JMPN(handleGas) ;:JMPN(ECADD)
-    A - 8               :JMPN(handleGas) ;:JMPN(ECMUL)
-    A - 9               :JMPN(handleGas) ;:JMPN(ECPAIRING)
-    A - 10              :JMPN(handleGas) ;:JMPN(BLAKE2F)
+    A - 7               :JMPN(readCode) ;:JMPN(ECADD)
+    A - 8               :JMPN(readCode) ;:JMPN(ECMUL)
+    A - 9               :JMPN(readCode) ;:JMPN(ECPAIRING)
+    A - 10              :JMPN(readCode) ;:JMPN(BLAKE2F)

--- a/main/process-tx.zkasm
+++ b/main/process-tx.zkasm
@@ -230,9 +230,7 @@ nonceIs0:
 endContractAddress:
         HASHPOS                         :HASHKLEN(E)
         $ => A                          :HASHKDIGEST(E)
-        12 => D
-                                        :CALL(SHLarith)
-                                        :CALL(SHRarith)
+                                        :CALL(maskAddress) ; Mask address to 20 bytes
         A                               :MSTORE(createContractAddress)
         A                               :MSTORE(txDestAddr)
         A                               :MSTORE(storageAddr)
@@ -295,9 +293,7 @@ create2end:
         C                               :HASHK(E)
         HASHPOS                         :HASHKLEN(E)
         $ => A                          :HASHKDIGEST(E)
-        12 => D
-                                        :CALL(SHLarith)
-                                        :CALL(SHRarith)
+                                        :CALL(maskAddress) ; Mask address to 20 bytes
         A                               :MSTORE(createContractAddress)
         A                               :MSTORE(txDestAddr)
         A                               :MSTORE(storageAddr)

--- a/main/utils.zkasm
+++ b/main/utils.zkasm
@@ -912,3 +912,14 @@ hashPoseidonReturn:
     $ => C          :MLOAD(tmpVarC)
     $ => E          :MLOAD(tmpVarE)
                     :RETURN
+
+
+; @info Mask address to 20 bytes
+; @in A => address not masked
+; @out A => masked address
+maskAddress:
+    B               :MSTORE(tmpVarB)
+    0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFn => B
+    $ => A          :AND
+    $ => B          :MLOAD(tmpVarB)
+                    :RETURN


### PR DESCRIPTION
- Mask address to 20 bytes for opcodes input
- Call readCode at precompiled selectors in case they are called from a new context