### PR TITLE
Fix for stCallCodes tests

### DIFF
--- a/main/opcodes.zkasm
+++ b/main/opcodes.zkasm
@@ -2834,13 +2834,20 @@ opCREATE2:
     E                   :MSTORE(lastMemOffset)
     C                   :MSTORE(lastMemLength)
                         :CALL(saveMem)
-    C => E
     CTX                 :MSTORE(originAuxCTX)
-    $ => B              :MLOAD(txDestAddr)
+    $ => E              :MLOAD(txDestAddr)
     GAS - 32000 => GAS  :JMPN(outOfGas)
     ; Cost to hash the initialisation code before
-    ${(C+31)/32} => C
-    GAS - 6*C => GAS    :JMPN(outOfGas)
+    ; Div operation with Arith
+    ${C+31}             :MSTORE(arithA)
+    32                  :MSTORE(arithB)
+                        :CALL(divARITH)
+    $ => C              :MLOAD(arithRes1)
+    GAS => A
+    6*C => B
+    $                   :LT,JMPC(outOfGas)
+    A - B => GAS
+
     GAS => C            :MSTORE(gasCall)
     SP                  :MSTORE(lastSP)
     PC                  :MSTORE(lastPC)
@@ -2860,10 +2867,9 @@ opCREATE2:
     GAS - A             :MSTORE(gasCTX)
     $ => CTX            :MLOAD(currentCTX)
     A => GAS
-    B                   :MSTORE(txSrcAddr)
-    ; TODO is not encesesaary to load and store GAS, bc is global var
+    E                   :MSTORE(txSrcAddr)
                         :CALL(copySP)
-    B => A
+    $ => A              :MLOAD(txSrcAddr)
     %SMT_KEY_NONCE => B
     0 => C                                                                                  ; 3rd parameter does not apply to nonce
     $ => B              :SLOAD

--- a/main/opcodes.zkasm
+++ b/main/opcodes.zkasm
@@ -2834,10 +2834,13 @@ opCREATE2:
     E                   :MSTORE(lastMemOffset)
     C                   :MSTORE(lastMemLength)
                         :CALL(saveMem)
-
+    C => E
     CTX                 :MSTORE(originAuxCTX)
     $ => B              :MLOAD(txDestAddr)
     GAS - 32000 => GAS  :JMPN(outOfGas)
+    ; Cost to hash the initialisation code before
+    ${(C+31)/32} => C
+    GAS - 6*C => GAS    :JMPN(outOfGas)
     GAS => C            :MSTORE(gasCall)
     SP                  :MSTORE(lastSP)
     PC                  :MSTORE(lastPC)
@@ -2946,8 +2949,6 @@ opSTATICCALL:
     C               :MSTORE(txGasPrice)
     $ => A          :MLOAD(argsLengthCall)
     A               :MSTORE(txCalldataLen)
-    $ => E          :MLOAD(argsOffsetCall) ;offset
-    $ => C          :MLOAD(argsLengthCall) ;length
                     :CALL(copySP)
                     :JMP(txType)
 

--- a/main/precompiled/selector.zkasm
+++ b/main/precompiled/selector.zkasm
@@ -10,11 +10,11 @@ INCLUDE "end.zkasm"
  */
 selectorPrecompiled:
     A - 2               :JMPN(funcECRECOVER)
-    A - 3               :JMPN(readCode)  ;:JMPN(SHA256)
-    A - 4               :JMPN(readCode)  ;:JMPN(RIPEMD160)
+    A - 3               :JMPN(callContract)  ;:JMPN(SHA256)
+    A - 4               :JMPN(callContract)  ;:JMPN(RIPEMD160)
     A - 5               :JMPN(IDENTITY)
     A - 6               :JMPN(MODEXP)
-    A - 7               :JMPN(readCode) ;:JMPN(ECADD)
-    A - 8               :JMPN(readCode) ;:JMPN(ECMUL)
-    A - 9               :JMPN(readCode) ;:JMPN(ECPAIRING)
-    A - 10              :JMPN(readCode) ;:JMPN(BLAKE2F)
+    A - 7               :JMPN(callContract) ;:JMPN(ECADD)
+    A - 8               :JMPN(callContract) ;:JMPN(ECMUL)
+    A - 9               :JMPN(callContract) ;:JMPN(ECPAIRING)
+    A - 10              :JMPN(callContract) ;:JMPN(BLAKE2F)

--- a/main/process-tx.zkasm
+++ b/main/process-tx.zkasm
@@ -34,10 +34,13 @@ processTx:
         ; Check result is non-zero
 checkAndSaveFrom:
         0 => B
-        $                               :EQ,JMPC(invalidIntrinsicTx)
         A                               :MSTORE(txSrcAddr)
         A                               :MSTORE(txSrcOriginAddr)
         ${eventLog(onProcessTx)}
+        $                               :EQ,JMPC(invalidIntrinsicTx)
+;;;;;;;;;
+;; Store init state
+;;;;;;;;;
 
         ; Store initial state at the beginning of the transaction
         SR                              :MSTORE(originSR)
@@ -254,14 +257,6 @@ endContractAddress:
 ;; compute new contract address as CREATE2 spec: keccak256(0xff ++ address ++ salt ++ keccak256(init_code))[12:] (https://eips.ethereum.org/EIPS/eip-1014)
 create2:
         $ => C                          :MLOAD(txCalldataLen)
-        ; Div operation with Arith
-        ${(C+31)/32} => A
-        ${C+31}                         :MSTORE(arithA)
-        32                              :MSTORE(arithB)
-                                        :CALL(divARITH)
-        $ => A                          :MLOAD(arithRes1)
-
-        GAS - 6*A => GAS                :JMPN(outOfGas)
         $ => CTX                        :MLOAD(originCTX)
         $ => B                          :MLOAD(argsOffsetCall)
 
@@ -299,8 +294,8 @@ create2end:
         20 => D
         $ => A                          :MLOAD(txSrcAddr)
         A                               :HASHK(E)
-        $ => B                          :MLOAD(salt)
         32 => D
+        $ => B                          :MLOAD(salt)
         B                               :HASHK(E)
         32 => D
         C                               :HASHK(E)
@@ -340,7 +335,7 @@ readDeployBytecode:
         0 - B                           :JMPN(readDeployBytecodeCreate)
         ; check enough bytes to read in calldata
         $ => B                          :MLOAD(txCalldataLen)
-        B - PC - 1                      :JMPN(defaultOpCode)
+        B - PC - 1                      :JMPN(defaultOpCode) 
         $ => HASHPOS                    :MLOAD(dataStarts)
         HASHPOS + PC => HASHPOS
         $ => E                          :MLOAD(batchHashDataId)
@@ -352,8 +347,8 @@ readDeployBytecode:
 
 ;; read calldata bytes of a CREATE/CREATE2 call and process them
 readDeployBytecodeCreate:
+        $ => E                          :MLOAD(txCalldataLen)
         $ => CTX                        :MLOAD(originCTX)
-        $ => E                          :MLOAD(argsLengthCall)
         ; check enough bytes to read in memory
         E - PC - 1                      :JMPN(readDeployBytecodeCreateDefault)
 
@@ -548,4 +543,4 @@ invalidIntrinsicTx:
 ;; handle error no more bytecode to read
 defaultOpCode:
         ${eventLog(onOpcode(0))}
-                                        :JMP(opSTOP)
+                                        :JMP(opSTOP) 


### PR DESCRIPTION
WARNING: This PR https://github.com/0xPolygonHermez/zkevm-rom/pull/115 should me merged first

- Moved 6 GAS computation from a create to the opcode file (not process tx)
- Removed unused mload (argsOffset + argsLength) from opSTATICCALL
- Moved label eventLog(onProcessTx) to be triggered before any intrinsic check
- At `readDeployBytecodeCreate:` get calldata len from txCalldataLen (CTX var) not argsLengthCall (GLOBAL var), this was creating bugs for transactions with more than one create from the same origin context