### PR TITLE
mask 1 byte before hashK

### DIFF
--- a/main/process-tx.zkasm
+++ b/main/process-tx.zkasm
@@ -21,7 +21,7 @@ processTx:
         %MAX_CNT_STEPS - STEP - 100000 :JMPN(outOfCounters)
         ; Get sigDataSize
         $ => HASHPOS                     :MLOAD(sigDataSize)
-        
+
         ; Check keccak counters
         HASHPOS                          :MSTORE(arithA)
         136                              :MSTORE(arithB)
@@ -47,7 +47,7 @@ processTx:
 checkAndSaveFrom:
         0 => B
         A                               :MSTORE(txSrcAddr)
-        A                               :MSTORE(txSrcOriginAddr)       
+        A                               :MSTORE(txSrcOriginAddr)
         $                               :EQ,JMPC(invalidIntrinsicTx)
 
 ;;;;;;;;;
@@ -73,8 +73,8 @@ endCheckChainId:
         ${resetTouchedAddress()} ; clean touchedAddresses since there is a new transaction
         ${resetStorageSlots()} ; clean storageSlots since there is a new transaction
         ${touchedAddress(A)} ; add tx.origin to touched addresses
-        
-;; Set gasPrice global var 
+
+;; Set gasPrice global var
         $ => A                          :MLOAD(txGasPriceRLP)
         A                               :MSTORE(txGasPrice)
 ;;;;;;;;;;;;;;;;;;
@@ -228,7 +228,7 @@ getContractAddress:
         $ => A                          :MLOAD(isCreate2)
         0 - A                           :JMPN(create2)
         $ => A                          :MLOAD(txNonce)
-        0x80 => B                     
+        0x80 => B
         $                               :LT,JMPC(nonce1byte)
         $ => C                          :MLOAD(lengthNonce)
         1 => D
@@ -328,7 +328,7 @@ create2end:
         32 => D
         C                               :HASHK(E)
         HASHPOS                         :HASHKLEN(E)
-        
+
         ; Check keccak counters
         HASHPOS                         :MSTORE(arithA)
         136                             :MSTORE(arithB)
@@ -386,7 +386,7 @@ readDeployBytecode:
         0 - B                           :JMPN(readDeployBytecodeCreate)
         ; check enough bytes to read in calldata
         $ => B                          :MLOAD(txCalldataLen)
-        B - PC - 1                      :JMPN(defaultOpCode) 
+        B - PC - 1                      :JMPN(defaultOpCode)
         $ => HASHPOS                    :MLOAD(dataStarts)
         HASHPOS + PC => HASHPOS
         $ => E                          :MLOAD(batchHashDataId)
@@ -595,4 +595,4 @@ invalidIntrinsicTx:
 ;; handle error no more bytecode to read
 defaultOpCode:
         ${eventLog(onOpcode(0))}
-                                        :JMP(opSTOP) 
+                                        :JMP(opSTOP)

--- a/main/utils.zkasm
+++ b/main/utils.zkasm
@@ -867,6 +867,9 @@ utilsAddBatchHashBytebyByte:
         32 - D => D
         $ => A                          :MLOAD(auxBytes)
         zkPC+1 => RR                    :JMP(SHRarith)
+        ; get last byte
+        0xFFn => B
+        $ => A                          :AND
         D => B
         1 => D
         zkPC+1 => RR                    :JMP(addBatchHashData)


### PR DESCRIPTION
This PR does the following:
- before adding 1 byte with `hashK` instruction assure that value has indeed 1 byte. Otherwise, plookup will fail