### PR TITLE
Feature/pre eip155

### DIFF
--- a/main/load-tx-rlp.zkasm
+++ b/main/load-tx-rlp.zkasm
@@ -228,7 +228,10 @@ readDataFinal:
                                         :CALL(addBatchHashByteByByte)
 
 endData:
-
+        ; Check all bytes read to detect pre EIP-155 tx
+        C => A
+        $ => B                          :MLOAD(txRLPLength)
+        $                               :EQ,JMPC(setPreEIP155Flag)
 
 ;; Read RLP 'chainId'
         ; 64 bits max
@@ -237,11 +240,11 @@ chainREAD:
                                         :CALL(addHashTx)
                                         :CALL(addBatchHashData)
         A - 0x80                        :JMPN(endChainId)
-        A - 0x81                        :JMPN(chanId0)
+        A - 0x81                        :JMPN(chainId0)
         A - 0x89                        :JMPN(shortChainId)
                                         :JMP(invalidTxRLP)
 
-chanId0:
+chainId0:
         0 => A
                                         :JMPN(endChainId)
 
@@ -262,7 +265,9 @@ endChainId:
         0x8080 => B
         $                               :EQ,JMPC(sizeVerification)
                                         :JMP(invalidTxRLP)
-
+                                        
+setPreEIP155Flag:
+        1                               :MSTORE(isPreEIP155)
 ;; size verification
         ; checks RLP lenght read at the RLP header with bytes read during RLP parsing
 sizeVerification:
@@ -304,7 +309,6 @@ vREADTx:
 ;;;;;;;;;
 ;; D - Finish RLP parsing
 ;;;;;;;;;
-
 ;; update bytes parsed
         $ => A                          :MLOAD(batchL2DataParsed)
         A + C => A                      :MSTORE(batchL2DataParsed)

--- a/main/main.zkasm
+++ b/main/main.zkasm
@@ -203,10 +203,10 @@ assertNewLocalExitRoot:
         HASHPOS                         :HASHKLEN(0)
 
         $ => A                          :MLOAD(globalHash)
+        ${eventLog(onFinishBatch)}
 assertNewStateRoot:
         $                               :HASHKDIGEST(0), ASSERT
 
-        ${eventLog(onFinishBatch)}
 
 ;;;;;;;;;;;;;;;;;;
 ;; F - Finalize execution

--- a/main/process-tx.zkasm
+++ b/main/process-tx.zkasm
@@ -73,10 +73,13 @@ checkAndSaveFrom:
 ;; C - Verify chainID
 ;;;;;;;;;;;;;;;;;;
 
+        $ => A                          :MLOAD(isPreEIP155)
+        ; Don't check chainId for legacy transactions
+        0 - A                           :JMPN(endCheckChainId)
         $ => A                          :MLOAD(txChainId)
         $ => B                          :MLOAD(chainId)                                       ; A: chainId tx
-        $                               :EQ,JMPC(endCheckChainId)                               ; If A == B --> endCheckChainId
-                                        :JMP(invalidIntrinsicTxChainId)                                         ; If A != B --> invalidIntrinsicTx
+        $                               :EQ,JMPC(endCheckChainId)                             ; If A == B --> endCheckChainId
+                                        :JMP(invalidIntrinsicTxChainId)                       ; If A != B --> invalidIntrinsicTx
 endCheckChainId:
 
 ;; Reset warm/cold information

--- a/main/process-tx.zkasm
+++ b/main/process-tx.zkasm
@@ -141,7 +141,6 @@ loopBytes:
         %MAX_CNT_STEPS - STEP - 20 :JMPN(outOfCountersStep)
         A - C - 1                       :JMPN(endCalldataIntrinsicGas)
         E => B
-        HASHPOS => D
         1 => D
         $ => E                          :MLOAD(batchHashDataId)
         $ => D                          :HASHK(E)

--- a/main/vars.zkasm
+++ b/main/vars.zkasm
@@ -84,3 +84,4 @@ VAR CTX gasCTX ; remaining gas in the origin CTX when a new context is created
 VAR CTX sigDataSize ; hash position for the ethereum transaction hash
 VAR CTX dataStarts; hash position where de transaction 'data' starts in the batchHashData
 VAR CTX SPw ; aux variable to store Stack poimnter 'SP'
+VAR CTX isPreEIP155 ; flag to check if the current tx is legacy, previous to Spurious Dragon (EIP-155)

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "yargs": "^17.5.1"
   },
   "devDependencies": {
-    "@0xpolygonhermez/zkevm-proverjs": "github:0xPolygonHermez/zkevm-proverjs#v0.4.1.0",
-    "@0xpolygonhermez/zkevm-testvectors": "github:0xPolygonHermez/zkevm-testvectors#develop",
+    "@0xpolygonhermez/zkevm-proverjs": "github:0xPolygonHermez/zkevm-proverjs#feature/pre-EIP155",
+    "@0xpolygonhermez/zkevm-testvectors": "github:0xPolygonHermez/zkevm-testvectors#feature/pre-EIP155",
     "chai": "^4.3.6",
     "chalk": "^3.0.0",
     "eslint": "^8.25.0",


### PR DESCRIPTION
- Dont check chainID at rlp-process for legacy transactions
- Moved onFinishBatch event to trigger event before assert
- Dont compare tx chain id with sequencer chain id for legacy txs
- Removed unnecessary D assignation, from issue (https://github.com/0xPolygonHermez/zkevm-rom/issues/136)