### PR TITLE
minor changes + last commit zkasmcom

### DIFF
--- a/main/opcodes/arithmetic.zkasm
+++ b/main/opcodes/arithmetic.zkasm
@@ -206,7 +206,7 @@ opADDMOD:
     $ => A          :MLOAD(SP--)
     $ => B          :MLOAD(SP--)
     ; Add operation with Arith
-    ${var _addMod = A + B} ; TODO $$
+    $${var _addMod = A + B}
 
     1 => D
     $ => A          :ADD, JMPC(AddModJumpCarry) ; or arith

--- a/main/precompiled/selector.zkasm
+++ b/main/precompiled/selector.zkasm
@@ -5,7 +5,7 @@ INCLUDE "end.zkasm"
 
 /**
  * Selector precompiled contract to run
- * Current precompiled supported: ECRECOVER, IDENTITY & MODEXP
+ * Current precompiled supported: ECRECOVER & IDENTITY
  * @param {A} - Precompiled address
  */
 selectorPrecompiled:
@@ -13,7 +13,7 @@ selectorPrecompiled:
     A - 3               :JMPN(callContract)  ;:JMPN(SHA256)
     A - 4               :JMPN(callContract)  ;:JMPN(RIPEMD160)
     A - 5               :JMPN(IDENTITY)
-    A - 6               :JMPN(MODEXP)
+    A - 6               :JMPN(callContract) ;:JMPN(MODEXP)
     A - 7               :JMPN(callContract) ;:JMPN(ECADD)
     A - 8               :JMPN(callContract) ;:JMPN(ECMUL)
     A - 9               :JMPN(callContract) ;:JMPN(ECPAIRING)

--- a/main/process-tx.zkasm
+++ b/main/process-tx.zkasm
@@ -21,6 +21,15 @@ processTx:
 ;;;;;;;;;;;;;;;;;;
 
         ${eventLog(onProcessTx)}
+
+;;;;;;;;;
+;; Store init state
+;;;;;;;;;
+
+        ; Store initial state at the beginning of the transaction
+        SR                              :MSTORE(originSR)
+        SR                              :MSTORE(initSR)
+
         ; Minimum of 100000 steps left to process a tx
         %MAX_CNT_STEPS - STEP - 100000 :JMPN(outOfCountersStep)
         ; Get sigDataSize
@@ -52,14 +61,6 @@ checkAndSaveFrom:
         A                               :MSTORE(txSrcAddr)
         A                               :MSTORE(txSrcOriginAddr)
         $                               :EQ,JMPC(invalidIntrinsicTxSignature)
-
-;;;;;;;;;
-;; Store init state
-;;;;;;;;;
-
-        ; Store initial state at the beginning of the transaction
-        SR                              :MSTORE(originSR)
-        SR                              :MSTORE(initSR)
 
 ;;;;;;;;;;;;;;;;;;
 ;; B - Verify tx.sender does not have any code deployed (EIP3607)

--- a/main/utils.zkasm
+++ b/main/utils.zkasm
@@ -734,8 +734,6 @@ handleError:
     ;revert all state changes
     $ => SR         :MLOAD(initSR)
                     :CALL(revertTouched)
-
-handleInvalidStatic:
     ;remaining gas = 0
     $ => A          :MLOAD(originCTX)
     0 => B
@@ -1103,7 +1101,7 @@ utilMULMOD:
     ;k.h * 2²⁵⁶ * N  = D2 * 2²⁵⁶ --> k.h  * N  = D2
 
     ; Mul operation with Arith
-    ${var _mulMod = A * B} ; TODO $$
+    $${var _mulMod = A * B}
     A               :MSTORE(arithA)
     B               :MSTORE(arithB)
     ; here we perform the: A * B + 0 = D*2^256 + E

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@0xpolygonhermez/zkevm-proverjs": "github:0xPolygonHermez/zkevm-proverjs#develop",
-    "@0xpolygonhermez/zkevm-testvectors": "github:0xPolygonHermez/zkevm-testvectors#feature/remove-modexp",
+    "@0xpolygonhermez/zkevm-testvectors": "github:0xPolygonHermez/zkevm-testvectors#develop",
     "chai": "^4.3.6",
     "chalk": "^3.0.0",
     "eslint": "^8.25.0",

--- a/package.json
+++ b/package.json
@@ -28,12 +28,12 @@
     "url": "https://github.com/0xPolygonHermez/zkevm-rom.git"
   },
   "dependencies": {
-    "@0xpolygonhermez/zkasmcom": "https://github.com/0xPolygonHermez/zkasmcom.git#v0.4.0.0",
+    "@0xpolygonhermez/zkasmcom": "https://github.com/0xPolygonHermez/zkasmcom.git#1cf5c2ce695a6bf6e38913643576d728ba771c64",
     "yargs": "^17.5.1"
   },
   "devDependencies": {
-    "@0xpolygonhermez/zkevm-proverjs": "github:0xPolygonHermez/zkevm-proverjs#feature/recursive-new",
-    "@0xpolygonhermez/zkevm-testvectors": "github:0xPolygonHermez/zkevm-testvectors#develop",
+    "@0xpolygonhermez/zkevm-proverjs": "github:0xPolygonHermez/zkevm-proverjs#develop",
+    "@0xpolygonhermez/zkevm-testvectors": "github:0xPolygonHermez/zkevm-testvectors#feature/remove-modexp",
     "chai": "^4.3.6",
     "chalk": "^3.0.0",
     "eslint": "^8.25.0",

--- a/tools/gen-parallel-tests.js
+++ b/tools/gen-parallel-tests.js
@@ -59,6 +59,7 @@ async function main() {
     const pilConfig = {
         defines: { N: 4096 },
         namespaces: ['Main', 'Global'],
+        disableUnusedError: true
     };
 
     const pil = await compile(F, pathMainPil, null, pilConfig);


### PR DESCRIPTION
This PR does the following:
- update `zksmcom` to last  commit
  - `isCode` memory section is deleted
  - memory is now 4MB
- remove `modexp`
- $ --> $$
  - fixed in `zkproverjs`
- remove label `handleInvalidStatic`
- fix get SR before any `invalidIntrinsic` found by @invocamanman 