### PR TITLE
Comments comparison opcodes

### DIFF
--- a/main/constants.zkasm
+++ b/main/constants.zkasm
@@ -38,5 +38,7 @@ CONST %MAX_CNT_KECCAK_F = (%MAX_CNT_STEPS / 158418) * 9
 CONST %MAX_CNT_PADDING_PG = (%MAX_CNT_STEPS / 56)
 CONST %MAX_CNT_POSEIDON_G = (%MAX_CNT_STEPS / 30)
 CONST %MIN_CNT_KECCAK_BATCH = 1 ; minimum necessary keccaks to compute global hash
+
 ; ETHEREUM CONSTANTS
 CONSTL %MAX_NONCE = 0xffffffffffffffffn
+CONSTL %MAX_UINT_256 = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffn

--- a/main/map-opcodes.zkasm
+++ b/main/map-opcodes.zkasm
@@ -1,6 +1,6 @@
 INCLUDE "opcodes/arithmetic.zkasm"
 INCLUDE "opcodes/block.zkasm"
-INCLUDE "opcodes/comparision.zkasm"
+INCLUDE "opcodes/comparison.zkasm"
 INCLUDE "opcodes/context-information.zkasm"
 INCLUDE "opcodes/create-terminate-context.zkasm"
 INCLUDE "opcodes/crypto.zkasm"

--- a/main/opcodes/arithmetic.zkasm
+++ b/main/opcodes/arithmetic.zkasm
@@ -24,8 +24,8 @@ opADD:
     $ => A          :MLOAD(SP--) ; [a => A]
     $ => B          :MLOAD(SP) ; [b => B]
 
-    ; call arith state machine and push to the stack
-    $               :ADD, MSTORE(SP++) ; [a + b => SP]
+    ; call binary:add state machine and push to the stack
+    $               :ADD, MSTORE(SP++)
 
     ; continue read bytecode
                     :JMP(readCode)
@@ -252,7 +252,7 @@ opMULMOD:
     C               :MSTORE(SP++)
                     :JMP(readCode)
 
-opEXP: ; //TODO: test exp == 0
+opEXP:
 
     %MAX_CNT_BINARY - CNT_BINARY - 5 :JMPN(outOfCountersBinary)
     %MAX_CNT_STEPS - STEP - 120 :JMPN(outOfCountersStep)
@@ -280,7 +280,6 @@ opSIGNEXTEND: ; following this impl https://github.com/ethereumjs/ethereumjs-mon
     $ => D          :MLOAD(SP)   ; number to convert
     30 => A
     $               :LT, JMPC(opSIGNEXTENDEnd); if signByte is 31 or more, means basically let the number as it is
-    ; TODO we could divide this opcode in a table with constants, only 31 cases
     B * 8  + 7 => D ; B is less than 31, no need for binary
     D*2 => RR
     zkPC+2                  :MSTORE(tmpSHXZkPC)
@@ -297,7 +296,7 @@ opSIGNEXTEND: ; following this impl https://github.com/ethereumjs/ethereumjs-mon
     0 => A
     $               :EQ, JMPC(opSIGNEXTENDPositive) ; If 0 means the sign bit was 0 --> positive
     C => A ; mask
-    0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffn => B
+    %MAX_UINT_256 => B
     $ => B          :XOR ; not mask
     D => A
     $ => D          :OR

--- a/main/opcodes/comparision.zkasm
+++ b/main/opcodes/comparision.zkasm
@@ -1,234 +1,410 @@
-
+/**
+ * @link [https://www.evm.codes/#10?fork=berlin]
+ * @zk-counters
+ *  - 1 binary
+ *  - 120 steps
+ * @process-opcode
+ *  - stack input: [a, b]
+ *  - stack output: [a < b]
+ */
 opLT:
-
+    ; checks zk-counters
     %MAX_CNT_BINARY - CNT_BINARY - 1 :JMPN(outOfCountersBinary)
     %MAX_CNT_STEPS - STEP - 120 :JMPN(outOfCountersStep)
 
+    ; check stack underflow
     SP - 2          :JMPN(stackUnderflow)
     SP - 1 => SP
     $ => A          :MLOAD(SP--)
     $ => B          :MLOAD(SP)
+    ; check out-of-gas
     GAS-3 => GAS    :JMPN(outOfGas)
+    ; if (a < b) [1 => SP] else [0 => SP] 
     $               :LT,MSTORE(SP++)
+    ; check stack overflow
     1024 - SP       :JMPN(stackOverflow)
                     :JMP(readCode)
 
+/**
+ * @link [https://www.evm.codes/#11?fork=berlin]
+ * @zk-counters
+ *  - 1 binary
+ *  - 120 steps
+ * @process-opcode
+ *  - stack input: [a, b]
+ *  - stack output: [a > b]
+ */
 opGT:
-
+    ; checks zk-counters
     %MAX_CNT_BINARY - CNT_BINARY - 1 :JMPN(outOfCountersBinary)
     %MAX_CNT_STEPS - STEP - 120 :JMPN(outOfCountersStep)
-
+    ; check stack underflow
     SP - 2          :JMPN(stackUnderflow)
     SP - 1 => SP
     $ => B          :MLOAD(SP--)
     $ => A          :MLOAD(SP)
+    ; check out-of-gas
     GAS-3 => GAS    :JMPN(outOfGas)
+    ; if (a > b) [1 => SP] else [0 => SP]
     $               :LT,MSTORE(SP++)
+    ; check stack overflow
     1024 - SP       :JMPN(stackOverflow)
                     :JMP(readCode)
 
+/**
+ * @link [https://www.evm.codes/#12?fork=berlin]
+ * @zk-counters
+ *  - 1 binary
+ *  - 120 steps
+ * @process-opcode
+ *  - stack input: [a, b]
+ *  - stack output: [a < b]
+ */
 opSLT:
-
+    ; checks zk-counters
     %MAX_CNT_BINARY - CNT_BINARY - 1 :JMPN(outOfCountersBinary)
     %MAX_CNT_STEPS - STEP - 120 :JMPN(outOfCountersStep)
-
+    ; check stack underflow
     SP - 2          :JMPN(stackUnderflow)
     SP - 1 => SP
     $ => A          :MLOAD(SP--)
     $ => B          :MLOAD(SP)
+    ; check out-of-gas
     GAS-3 => GAS    :JMPN(outOfGas)
+    ; if (a < b) [1 => SP] else [0 => SP]
     $               :SLT,MSTORE(SP++)
+    ; check stack overflow
     1024 - SP       :JMPN(stackOverflow)
                     :JMP(readCode)
 
+/**
+ * @link [https://www.evm.codes/#13?fork=berlin]
+ * @zk-counters
+ *  - 1 binary
+ *  - 120 steps
+ * @process-opcode
+ *  - stack input: [a, b]
+ *  - stack output: [a > b]
+ */
 opSGT:
-
+    ; checks zk-counters
     %MAX_CNT_BINARY - CNT_BINARY - 1 :JMPN(outOfCountersBinary)
     %MAX_CNT_STEPS - STEP - 120 :JMPN(outOfCountersStep)
-
+    ; check stack underflow
     SP - 2          :JMPN(stackUnderflow)
     SP - 1 => SP
     $ => B          :MLOAD(SP--)
     $ => A          :MLOAD(SP)
+    ; check out-of-gas
     GAS-3 => GAS    :JMPN(outOfGas)
+    ; if (a > b) [1 => SP] else [0 => SP]
     $               :SLT,MSTORE(SP++)
+    ; check stack overflow
     1024 - SP       :JMPN(stackOverflow)
                     :JMP(readCode)
 
+/**
+ * @link [https://www.evm.codes/#14?fork=berlin]
+ * @zk-counters
+ *  - 1 binary
+ *  - 120 steps
+ * @process-opcode
+ *  - stack input: [a, b]
+ *  - stack output: [a == b]
+ */
 opEQ:
-
+    ; checks zk-counters
     %MAX_CNT_BINARY - CNT_BINARY - 1 :JMPN(outOfCountersBinary)
     %MAX_CNT_STEPS - STEP - 120 :JMPN(outOfCountersStep)
-
+    ; check stack underflow
     SP - 2          :JMPN(stackUnderflow)
     SP - 1 => SP
     $ => A          :MLOAD(SP--)
     $ => B          :MLOAD(SP)
+    ; check out-of-gas
     GAS-3 => GAS    :JMPN(outOfGas)
+    ; if (a == b) [1 => SP] else [0 => SP]
     $               :EQ,MSTORE(SP++)
+    ; check stack overflow
     1024 - SP       :JMPN(stackOverflow)
                     :JMP(readCode)
 
+/**
+ * @link [https://www.evm.codes/#15?fork=berlin]
+ * @zk-counters
+ *  - 1 binary
+ *  - 120 steps
+ * @process-opcode
+ *  - stack input: [a]
+ *  - stack output: [a == 0]
+ */
 opISZERO:
-
+    ; checks zk-counters
     %MAX_CNT_BINARY - CNT_BINARY - 1 :JMPN(outOfCountersBinary)
     %MAX_CNT_STEPS - STEP - 120 :JMPN(outOfCountersStep)
-
+    ; check stack underflow
     SP - 1 => SP    :JMPN(stackUnderflow)
     $ => A          :MLOAD(SP)
+    ; check out-of-gas
     GAS-3 => GAS    :JMPN(outOfGas)
     0 => B
+    ; if (a == 0) [1 => SP] else [0 => SP]
     $               :EQ,MSTORE(SP++)
+    ; check stack overflow
     1024 - SP       :JMPN(stackOverflow)
                     :JMP(readCode)
 
+/**
+ * @link [https://www.evm.codes/#16?fork=berlin]
+ * @zk-counters
+ *  - 1 binary
+ *  - 120 steps
+ * @process-opcode
+ *  - stack input: [a, b]
+ *  - stack output: [a & b]
+ */
 opAND:
-
+    ; checks zk-counters
     %MAX_CNT_BINARY - CNT_BINARY - 1 :JMPN(outOfCountersBinary)
     %MAX_CNT_STEPS - STEP - 120 :JMPN(outOfCountersStep)
-
+    ; check stack underflow
     SP - 2          :JMPN(stackUnderflow)
     SP - 1 => SP
     $ => A          :MLOAD(SP--)
     $ => B          :MLOAD(SP)
+    ; check out-of-gas
     GAS-3 => GAS    :JMPN(outOfGas)
-    $               :AND,MSTORE(SP++)
+    $               :AND,MSTORE(SP++) ; [ a & b => SP]
+    ; check stack overflow
     1024 - SP       :JMPN(stackOverflow)
                     :JMP(readCode)
 
+/**
+ * @link [https://www.evm.codes/#17?fork=berlin]
+ * @zk-counters
+ *  - 1 binary
+ *  - 120 steps
+ * @process-opcode
+ *  - stack input: [a, b]
+ *  - stack output: [a | b]
+ */
 opOR:
-
+    ; checks zk-counters
     %MAX_CNT_BINARY - CNT_BINARY - 1 :JMPN(outOfCountersBinary)
     %MAX_CNT_STEPS - STEP - 120 :JMPN(outOfCountersStep)
-
+    ; check stack underflow
     SP - 2          :JMPN(stackUnderflow)
     SP - 1 => SP
     $ => A          :MLOAD(SP--)
     $ => B          :MLOAD(SP)
+    ; check out-of-gas
     GAS-3 => GAS    :JMPN(outOfGas)
-    $               :OR,MSTORE(SP++)
+    $               :OR,MSTORE(SP++) ; [ a | b => SP]
+    ; check stack overflow
     1024 - SP       :JMPN(stackOverflow)
                     :JMP(readCode)
 
+/**
+ * @link [https://www.evm.codes/#18?fork=berlin]
+ * @zk-counters
+ *  - 1 binary
+ *  - 120 steps
+ * @process-opcode
+ *  - stack input: [a, b]
+ *  - stack output: [a ^ b]
+ */
 opXOR:
-
+    ; checks zk-counters
     %MAX_CNT_BINARY - CNT_BINARY - 1 :JMPN(outOfCountersBinary)
     %MAX_CNT_STEPS - STEP - 120 :JMPN(outOfCountersStep)
-
+    ; check stack underflow
     SP - 2          :JMPN(stackUnderflow)
     SP - 1 => SP
     $ => A          :MLOAD(SP--)
     $ => B          :MLOAD(SP)
+    ; check out-of-gas
     GAS-3 => GAS    :JMPN(outOfGas)
-    $               :XOR,MSTORE(SP++)
+    $               :XOR,MSTORE(SP++) ; [ a ^ b => SP]
+    ; check stack overflow
     1024 - SP       :JMPN(stackOverflow)
                     :JMP(readCode)
 
+/**
+ * @link [https://www.evm.codes/#19?fork=berlin]
+ * @zk-counters
+ *  - 1 binary
+ *  - 120 steps
+ * @process-opcode
+ *  - stack input: [a]
+ *  - stack output: [ NOT a ]
+ */
 opNOT:
-
+    ; checks zk-counters
     %MAX_CNT_BINARY - CNT_BINARY - 1 :JMPN(outOfCountersBinary)
     %MAX_CNT_STEPS - STEP - 120 :JMPN(outOfCountersStep)
-
+    ; check stack underflow
     SP - 1 => SP    :JMPN(stackUnderflow)
     $ => A          :MLOAD(SP)
+    ; check out-of-gas
     GAS-3 => GAS    :JMPN(outOfGas)
     0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffn => B
-    $ => A          :XOR,MSTORE(SP++)
+    $ => A          :XOR,MSTORE(SP++) ; [ NOT a => SP]
+    ; check stack overflow
     1024 - SP       :JMPN(stackOverflow)
                     :JMP(readCode)
 
+/**
+ * @link [https://www.evm.codes/#1a?fork=berlin]
+ * @zk-counters
+ *  - 2 arith
+ *  - 4 binary
+ *  - 120 steps
+ * @process-opcode
+ *  - stack input: [byte offset, 32-byte value]
+ *  - stack output: [byte]
+ */
 opBYTE:
-
+    ; checks zk-counters
     %MAX_CNT_ARITH - CNT_ARITH - 2 :JMPN(outOfCountersArith)
     %MAX_CNT_BINARY - CNT_BINARY - 4 :JMPN(outOfCountersBinary)
     %MAX_CNT_STEPS - STEP - 120 :JMPN(outOfCountersStep)
-
+    ; check stack underflow
     SP - 2          :JMPN(stackUnderflow)
     SP - 1 => SP
     $ => B          :MLOAD(SP--)
     $ => A          :MLOAD(SP)
+    ; check out-of-gas
     GAS-3 => GAS    :JMPN(outOfGas)
+    ; if the byte offset is out of range --> JMP(opBYTE0)
     31 - B => D     :JMPN(opBYTE0)
+    ; A >> D => A
                     :CALL(SHRarith)
     255 => B
+    ; result A & 255 --> [ A & 255 => SP]
     $               :AND,MSTORE(SP++)
+    ; check stack overflow
     1024 - SP       :JMPN(stackOverflow)
                     :JMP(readCode)
 opBYTE0:
+    ; result 0 --> [ 0 => SP]
     0               :MSTORE(SP++)
+    ; check stack overflow
     1024 - SP       :JMPN(stackOverflow)
                     :JMP(readCode)
+
+/**
+ * @link [https://www.evm.codes/#1c?fork=berlin]
+ * @zk-counters
+ *  - 1 arith
+ *  - 3 binary
+ *  - 120 steps
+ * @process-opcode
+ *  - stack input: [shift, value]
+ *  - stack output: [value >> shift]
+ */
 opSHR:
-
+    ; checks zk-counters
     %MAX_CNT_ARITH - CNT_ARITH - 1 :JMPN(outOfCountersArith)
     %MAX_CNT_BINARY - CNT_BINARY - 3 :JMPN(outOfCountersBinary)
     %MAX_CNT_STEPS - STEP - 120 :JMPN(outOfCountersStep)
-
+    ; check stack underflow
     SP - 2          :JMPN(stackUnderflow)
     SP - 1 => SP
     $ => D          :MLOAD(SP--)
     $ => A          :MLOAD(SP)
-                    :CALL(SHRarithBit)
+    ; CALL shr util (with arith)
+                    :CALL(SHRarithBit)  ; [ A >> D => A]
     A               :MSTORE(SP++)
+    ; check stack overflow
     1024 - SP       :JMPN(stackOverflow)
+    ; check out-of-gas
     GAS-3 => GAS    :JMPN(outOfGas)
                     :JMP(readCode)
 
+/**
+ * @link [https://www.evm.codes/#1b?fork=berlin]
+ * @zk-counters
+ *  - 1 arith
+ *  - 3 binary
+ *  - 120 steps
+ * @process-opcode
+ *  - stack input: [shift, value]
+ *  - stack output: [value << shift]
+ */
 opSHL:
-
+    ; checks zk-counters
     %MAX_CNT_ARITH - CNT_ARITH - 1 :JMPN(outOfCountersArith)
     %MAX_CNT_BINARY - CNT_BINARY - 3 :JMPN(outOfCountersBinary)
     %MAX_CNT_STEPS - STEP - 120 :JMPN(outOfCountersStep)
-
+    ; check stack underflow
     SP - 2          :JMPN(stackUnderflow)
     SP - 1 => SP
     $ => D          :MLOAD(SP--)
     $ => A          :MLOAD(SP)
-                    :CALL(SHLarithBit)
+    ; CALL shl util (with arith)
+                    :CALL(SHLarithBit)  ; [ A << D => A]
     A               :MSTORE(SP++)
+    ; check stack overflow
     1024 - SP       :JMPN(stackOverflow)
+    ; check out-of-gas
     GAS-3 => GAS    :JMPN(outOfGas)
                     :JMP(readCode)
 
+/**
+ * @link [https://www.evm.codes/#1d?fork=berlin]
+ * @zk-counters
+ *  - 2 arith
+ *  - 10 binary
+ *  - 200 steps
+ * @process-opcode
+ *  - stack input: [shift, value]
+ *  - stack output: [value >> shift (signed)]
+ */
 ; TODO: Adapt to multiplication
 ; https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/evm/src/opcodes/functions.ts#L336
 opSAR:
-
+    ; checks zk-counters
     %MAX_CNT_ARITH - CNT_ARITH - 2 :JMPN(outOfCountersArith)
     %MAX_CNT_BINARY - CNT_BINARY - 10 :JMPN(outOfCountersBinary)
     %MAX_CNT_STEPS - STEP - 200 :JMPN(outOfCountersStep)
-
+    ; check stack underflow
     SP - 2          :JMPN(stackUnderflow)
     SP - 1 => SP
-    $ => D          :MLOAD(SP--)
-    ${D/8} => B
+    $ => D          :MLOAD(SP--)    ; [shift (bits) => D]
+    ${D/8} => B                     ; [shift (bytes) => B]
     32 => A
-    $ => A          :LT
+    $ => A          :LT             ; if (shift (bytes) > 32) 1 => A, else 0 => A
     1 => B
-    $ => B          :XOR
-    ${A * 256 + B * D} => D
-    $ => A          :MLOAD(SP)
+    $ => B          :XOR            ; if (A == 1) 0 => B, else 1 => B
+    ${A * 256 + B * D} => D         ; if (shift (bytes) > 32) 256 => D, else D => D
+    $ => A          :MLOAD(SP)      ; [value => A]
+    ; CALL abs: Get absolute value (A) and sign (B)
                     :CALL(abs)
+    ; CALL shr util (with arith)
                     ; if more than 32 set to 32
                     :CALL(SHRarithBit)
-    A => C
-    B => A
+    A => C                          ; [absolute value => C]
+    B => A                          ; [sign => A]
     1 => B
-    $ => B          :XOR
+    $ => B          :XOR            ; if (sign negative (A == 1)) 0 => B, else 1 => B
     B - 1           :JMPN(opSARNeg)  ; 0 negative, 1 positive
-    C               :MSTORE(SP++)
+    C               :MSTORE(SP++)   ; [absolute value => SP]
+    ; check stack overflow
     1024 - SP       :JMPN(stackOverflow)
+    ; check out-of-gas
     GAS-3 => GAS    :JMPN(outOfGas)
                     :JMP(readCode)
 
 opSARNeg:
-    C => A
+    C => A                          ; [absolute value => A]
     1 => B
-    $ => B          :LT
+    $ => B          :LT             ; if (absolute value < 1) 1 => B, else 0 => B
     ${A + B} => B                   ; TODO: This is UNSAFE
     0 => A
-    $ => A          :SUB
+    $ => A          :SUB            ; 0 - (absolute value + B) => A
     A               :MSTORE(SP++)
+    ; check stack overflow
     1024 - SP       :JMPN(stackOverflow)
+    ; check out-of-gas
     GAS-3 => GAS    :JMPN(outOfGas)
                     :JMP(readCode)

--- a/main/opcodes/comparison.zkasm
+++ b/main/opcodes/comparison.zkasm
@@ -14,15 +14,20 @@ opLT:
 
     ; check stack underflow
     SP - 2          :JMPN(stackUnderflow)
-    SP - 1 => SP
-    $ => A          :MLOAD(SP--)
-    $ => B          :MLOAD(SP)
+
     ; check out-of-gas
-    GAS-3 => GAS    :JMPN(outOfGas)
-    ; if (a < b) [1 => SP] else [0 => SP] 
-    $               :LT,MSTORE(SP++)
-    ; check stack overflow
-    1024 - SP       :JMPN(stackOverflow)
+    GAS - 3 => GAS    :JMPN(outOfGas)
+
+    ; read two items from stack
+    SP - 1 => SP
+    $ => A          :MLOAD(SP--) ; [a => A]
+    $ => B          :MLOAD(SP) ; [a => B]
+
+    ; call binary:lessThan state machine
+    ; and push the result into the stack
+    $               :LT, MSTORE(SP++) ; [(a < b) => SP]
+
+    ; continue read bytecode
                     :JMP(readCode)
 
 /**
@@ -38,17 +43,23 @@ opGT:
     ; checks zk-counters
     %MAX_CNT_BINARY - CNT_BINARY - 1 :JMPN(outOfCountersBinary)
     %MAX_CNT_STEPS - STEP - 120 :JMPN(outOfCountersStep)
+
     ; check stack underflow
     SP - 2          :JMPN(stackUnderflow)
-    SP - 1 => SP
-    $ => B          :MLOAD(SP--)
-    $ => A          :MLOAD(SP)
+
     ; check out-of-gas
-    GAS-3 => GAS    :JMPN(outOfGas)
-    ; if (a > b) [1 => SP] else [0 => SP]
-    $               :LT,MSTORE(SP++)
-    ; check stack overflow
-    1024 - SP       :JMPN(stackOverflow)
+    GAS - 3 => GAS    :JMPN(outOfGas)
+
+    ; read two items from the stack
+    SP - 1 => SP
+    $ => B          :MLOAD(SP--) ; [a => B]
+    $ => A          :MLOAD(SP) ; [b => A]
+
+    ; call binary:lessThan state machine
+    ; and push the result into the stack
+    $               :LT, MSTORE(SP++) ; [(b < a) => SP]
+
+    ; continue read bytecode
                     :JMP(readCode)
 
 /**
@@ -58,23 +69,29 @@ opGT:
  *  - 120 steps
  * @process-opcode
  *  - stack input: [a, b]
- *  - stack output: [a < b]
+ *  - stack output: [signed(a < b)]
  */
 opSLT:
     ; checks zk-counters
     %MAX_CNT_BINARY - CNT_BINARY - 1 :JMPN(outOfCountersBinary)
     %MAX_CNT_STEPS - STEP - 120 :JMPN(outOfCountersStep)
+
     ; check stack underflow
     SP - 2          :JMPN(stackUnderflow)
-    SP - 1 => SP
-    $ => A          :MLOAD(SP--)
-    $ => B          :MLOAD(SP)
+
     ; check out-of-gas
-    GAS-3 => GAS    :JMPN(outOfGas)
-    ; if (a < b) [1 => SP] else [0 => SP]
-    $               :SLT,MSTORE(SP++)
-    ; check stack overflow
-    1024 - SP       :JMPN(stackOverflow)
+    GAS - 3 => GAS    :JMPN(outOfGas)
+
+    ; read two items from the stack
+    SP - 1 => SP
+    $ => A          :MLOAD(SP--) ; [a => A]
+    $ => B          :MLOAD(SP) ; [b => B]
+
+    ; call binary:SignedLessThan state machine
+    ; and push the result into the stack
+    $               :SLT, MSTORE(SP++) ; [signed(a < b) => SP]
+
+    ; continue read bytecode
                     :JMP(readCode)
 
 /**
@@ -84,23 +101,29 @@ opSLT:
  *  - 120 steps
  * @process-opcode
  *  - stack input: [a, b]
- *  - stack output: [a > b]
+ *  - stack output: [signed(a > b)]
  */
 opSGT:
     ; checks zk-counters
     %MAX_CNT_BINARY - CNT_BINARY - 1 :JMPN(outOfCountersBinary)
     %MAX_CNT_STEPS - STEP - 120 :JMPN(outOfCountersStep)
+
     ; check stack underflow
     SP - 2          :JMPN(stackUnderflow)
-    SP - 1 => SP
-    $ => B          :MLOAD(SP--)
-    $ => A          :MLOAD(SP)
+
     ; check out-of-gas
-    GAS-3 => GAS    :JMPN(outOfGas)
-    ; if (a > b) [1 => SP] else [0 => SP]
-    $               :SLT,MSTORE(SP++)
-    ; check stack overflow
-    1024 - SP       :JMPN(stackOverflow)
+    GAS - 3 => GAS    :JMPN(outOfGas)
+
+    ; read two items from the stack
+    SP - 1 => SP
+    $ => B          :MLOAD(SP--) ; [a => B]
+    $ => A          :MLOAD(SP) ; [b => A]
+
+    ; call binary:SignedLessThan state machine
+    ; and push the result into the stack
+    $               :SLT, MSTORE(SP++) ; [signed(b < a) => SP]
+
+    ; continue read bytecode
                     :JMP(readCode)
 
 /**
@@ -116,17 +139,23 @@ opEQ:
     ; checks zk-counters
     %MAX_CNT_BINARY - CNT_BINARY - 1 :JMPN(outOfCountersBinary)
     %MAX_CNT_STEPS - STEP - 120 :JMPN(outOfCountersStep)
+
     ; check stack underflow
     SP - 2          :JMPN(stackUnderflow)
-    SP - 1 => SP
-    $ => A          :MLOAD(SP--)
-    $ => B          :MLOAD(SP)
+
     ; check out-of-gas
-    GAS-3 => GAS    :JMPN(outOfGas)
-    ; if (a == b) [1 => SP] else [0 => SP]
-    $               :EQ,MSTORE(SP++)
-    ; check stack overflow
-    1024 - SP       :JMPN(stackOverflow)
+    GAS - 3 => GAS    :JMPN(outOfGas)
+
+    ; read two items from the stack
+    SP - 1 => SP
+    $ => A          :MLOAD(SP--) ; [a => A]
+    $ => B          :MLOAD(SP) ; [b => B]
+
+    ; call binary:Equal state machine
+    ; and push the result into the stack
+    $               :EQ, MSTORE(SP++) ; [(a == b) => SP]
+
+    ; continue read bytecode
                     :JMP(readCode)
 
 /**
@@ -142,16 +171,22 @@ opISZERO:
     ; checks zk-counters
     %MAX_CNT_BINARY - CNT_BINARY - 1 :JMPN(outOfCountersBinary)
     %MAX_CNT_STEPS - STEP - 120 :JMPN(outOfCountersStep)
+
     ; check stack underflow
     SP - 1 => SP    :JMPN(stackUnderflow)
-    $ => A          :MLOAD(SP)
+
     ; check out-of-gas
-    GAS-3 => GAS    :JMPN(outOfGas)
+    GAS - 3 => GAS    :JMPN(outOfGas)
+
+    ; read one item from stack
+    $ => A          :MLOAD(SP) ; [a => B]
     0 => B
-    ; if (a == 0) [1 => SP] else [0 => SP]
-    $               :EQ,MSTORE(SP++)
-    ; check stack overflow
-    1024 - SP       :JMPN(stackOverflow)
+
+    ; call binary:Equal state machine
+    ; and push the result into the stack
+    $               :EQ, MSTORE(SP++) ; [(a == 0) ==> SP]
+
+    ; continue read bytecode
                     :JMP(readCode)
 
 /**
@@ -167,16 +202,23 @@ opAND:
     ; checks zk-counters
     %MAX_CNT_BINARY - CNT_BINARY - 1 :JMPN(outOfCountersBinary)
     %MAX_CNT_STEPS - STEP - 120 :JMPN(outOfCountersStep)
+
     ; check stack underflow
     SP - 2          :JMPN(stackUnderflow)
-    SP - 1 => SP
-    $ => A          :MLOAD(SP--)
-    $ => B          :MLOAD(SP)
+
     ; check out-of-gas
-    GAS-3 => GAS    :JMPN(outOfGas)
-    $               :AND,MSTORE(SP++) ; [ a & b => SP]
-    ; check stack overflow
-    1024 - SP       :JMPN(stackOverflow)
+    GAS - 3 => GAS    :JMPN(outOfGas)
+
+    ; read two items from the stack
+    SP - 1 => SP
+    $ => A          :MLOAD(SP--) ; [a => A]
+    $ => B          :MLOAD(SP) ; [b => B]
+
+    ; call binary:And state machine
+    ; and push the result into the stack
+    $               :AND, MSTORE(SP++) ; [ a & b => SP]
+
+    ; continue read bytecode
                     :JMP(readCode)
 
 /**
@@ -192,16 +234,23 @@ opOR:
     ; checks zk-counters
     %MAX_CNT_BINARY - CNT_BINARY - 1 :JMPN(outOfCountersBinary)
     %MAX_CNT_STEPS - STEP - 120 :JMPN(outOfCountersStep)
+
     ; check stack underflow
     SP - 2          :JMPN(stackUnderflow)
+
+    ; check out-of-gas
+    GAS - 3 => GAS    :JMPN(outOfGas)
+
+    ; read two items from the stack
     SP - 1 => SP
     $ => A          :MLOAD(SP--)
     $ => B          :MLOAD(SP)
-    ; check out-of-gas
-    GAS-3 => GAS    :JMPN(outOfGas)
-    $               :OR,MSTORE(SP++) ; [ a | b => SP]
-    ; check stack overflow
-    1024 - SP       :JMPN(stackOverflow)
+
+    ; call binary:Or state machine
+    ; and push the result into the stack
+    $               :OR, MSTORE(SP++) ; [ a | b => SP]
+
+    ; continue read bytecode
                     :JMP(readCode)
 
 /**
@@ -217,16 +266,23 @@ opXOR:
     ; checks zk-counters
     %MAX_CNT_BINARY - CNT_BINARY - 1 :JMPN(outOfCountersBinary)
     %MAX_CNT_STEPS - STEP - 120 :JMPN(outOfCountersStep)
+
     ; check stack underflow
     SP - 2          :JMPN(stackUnderflow)
-    SP - 1 => SP
-    $ => A          :MLOAD(SP--)
-    $ => B          :MLOAD(SP)
+
     ; check out-of-gas
-    GAS-3 => GAS    :JMPN(outOfGas)
+    GAS - 3 => GAS    :JMPN(outOfGas)
+
+    ; read two items from the stack
+    SP - 1 => SP
+    $ => A          :MLOAD(SP--) ; [a => A]
+    $ => B          :MLOAD(SP) ; [b => B]
+
+    ; call binary:Xor state machine
+    ; and push the result into the stack
     $               :XOR,MSTORE(SP++) ; [ a ^ b => SP]
-    ; check stack overflow
-    1024 - SP       :JMPN(stackOverflow)
+
+    ; continue read bytecode
                     :JMP(readCode)
 
 /**
@@ -236,18 +292,23 @@ opXOR:
  *  - 120 steps
  * @process-opcode
  *  - stack input: [a]
- *  - stack output: [ NOT a ]
+ *  - stack output: [ ~a ]
  */
 opNOT:
     ; checks zk-counters
     %MAX_CNT_BINARY - CNT_BINARY - 1 :JMPN(outOfCountersBinary)
     %MAX_CNT_STEPS - STEP - 120 :JMPN(outOfCountersStep)
+
     ; check stack underflow
     SP - 1 => SP    :JMPN(stackUnderflow)
-    $ => A          :MLOAD(SP)
+
     ; check out-of-gas
-    GAS-3 => GAS    :JMPN(outOfGas)
-    0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffn => B
+    GAS - 3 => GAS    :JMPN(outOfGas)
+
+    ; read one item from the stack
+    $ => A          :MLOAD(SP)
+
+    0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffn => B ; 2**226 - 1 => 
     $ => A          :XOR,MSTORE(SP++) ; [ NOT a => SP]
     ; check stack overflow
     1024 - SP       :JMPN(stackOverflow)
@@ -268,28 +329,35 @@ opBYTE:
     %MAX_CNT_ARITH - CNT_ARITH - 2 :JMPN(outOfCountersArith)
     %MAX_CNT_BINARY - CNT_BINARY - 4 :JMPN(outOfCountersBinary)
     %MAX_CNT_STEPS - STEP - 120 :JMPN(outOfCountersStep)
+
     ; check stack underflow
     SP - 2          :JMPN(stackUnderflow)
-    SP - 1 => SP
-    $ => B          :MLOAD(SP--)
-    $ => A          :MLOAD(SP)
+
     ; check out-of-gas
-    GAS-3 => GAS    :JMPN(outOfGas)
+    GAS - 3 => GAS    :JMPN(outOfGas)
+
+    ; read two items from the stack
+    SP - 1 => SP
+    $ => B          :MLOAD(SP--) ; [byte offset => B]
+    $ => A          :MLOAD(SP) ; [32-byte value => A]
+
     ; if the byte offset is out of range --> JMP(opBYTE0)
     31 - B => D     :JMPN(opBYTE0)
-    ; A >> D => A
-                    :CALL(SHRarith)
+
+    ; call util function
+                    :CALL(SHRarith) ; [A >> D => A]
+
+    ; call binary:and state machine and push to the stack
     255 => B
-    ; result A & 255 --> [ A & 255 => SP]
-    $               :AND,MSTORE(SP++)
-    ; check stack overflow
-    1024 - SP       :JMPN(stackOverflow)
+    $               :AND, MSTORE(SP++) ; [ A & 255 => SP]
+
+    ; continue read bytecode
                     :JMP(readCode)
+
 opBYTE0:
-    ; result 0 --> [ 0 => SP]
-    0               :MSTORE(SP++)
-    ; check stack overflow
-    1024 - SP       :JMPN(stackOverflow)
+    0               :MSTORE(SP++) ; [ 0 => SP]
+
+    ; continue read bytecode
                     :JMP(readCode)
 
 /**
@@ -304,21 +372,26 @@ opBYTE0:
  */
 opSHR:
     ; checks zk-counters
-    %MAX_CNT_ARITH - CNT_ARITH - 1 :JMPN(outOfCountersArith)
-    %MAX_CNT_BINARY - CNT_BINARY - 3 :JMPN(outOfCountersBinary)
-    %MAX_CNT_STEPS - STEP - 120 :JMPN(outOfCountersStep)
+    %MAX_CNT_ARITH - CNT_ARITH - 1      :JMPN(outOfCountersArith)
+    %MAX_CNT_BINARY - CNT_BINARY - 3    :JMPN(outOfCountersBinary)
+    %MAX_CNT_STEPS - STEP - 120         :JMPN(outOfCountersStep)
+
     ; check stack underflow
-    SP - 2          :JMPN(stackUnderflow)
-    SP - 1 => SP
-    $ => D          :MLOAD(SP--)
-    $ => A          :MLOAD(SP)
-    ; CALL shr util (with arith)
-                    :CALL(SHRarithBit)  ; [ A >> D => A]
-    A               :MSTORE(SP++)
-    ; check stack overflow
-    1024 - SP       :JMPN(stackOverflow)
+    SP - 2              :JMPN(stackUnderflow)
+
     ; check out-of-gas
-    GAS-3 => GAS    :JMPN(outOfGas)
+    GAS - 3 => GAS      :JMPN(outOfGas)
+
+    ; read two items from the stack
+    SP - 1 => SP
+    $ => D          :MLOAD(SP--) ; [shift => D]
+    $ => A          :MLOAD(SP) ; [value => A]
+
+    ; call SHRarithBit util
+                    :CALL(SHRarithBit)  ; [ A >> D => A]
+    A               :MSTORE(SP++) ; [ A => SP]
+
+    ; continue read bytecode
                     :JMP(readCode)
 
 /**
@@ -333,78 +406,103 @@ opSHR:
  */
 opSHL:
     ; checks zk-counters
-    %MAX_CNT_ARITH - CNT_ARITH - 1 :JMPN(outOfCountersArith)
-    %MAX_CNT_BINARY - CNT_BINARY - 3 :JMPN(outOfCountersBinary)
-    %MAX_CNT_STEPS - STEP - 120 :JMPN(outOfCountersStep)
+    %MAX_CNT_ARITH - CNT_ARITH - 1      :JMPN(outOfCountersArith)
+    %MAX_CNT_BINARY - CNT_BINARY - 3    :JMPN(outOfCountersBinary)
+    %MAX_CNT_STEPS - STEP - 120         :JMPN(outOfCountersStep)
+
     ; check stack underflow
-    SP - 2          :JMPN(stackUnderflow)
+    SP - 2              :JMPN(stackUnderflow)
+
+    ; check out-of-gas
+    GAS - 3 => GAS      :JMPN(outOfGas)
+
+    ; read two items from the stack
     SP - 1 => SP
     $ => D          :MLOAD(SP--)
     $ => A          :MLOAD(SP)
-    ; CALL shl util (with arith)
+
+    ; CALL shl util
                     :CALL(SHLarithBit)  ; [ A << D => A]
-    A               :MSTORE(SP++)
-    ; check stack overflow
-    1024 - SP       :JMPN(stackOverflow)
-    ; check out-of-gas
-    GAS-3 => GAS    :JMPN(outOfGas)
+    A               :MSTORE(SP++) ; [A => SP]
+
+    ; continue read bytecode
                     :JMP(readCode)
 
 /**
  * @link [https://www.evm.codes/#1d?fork=berlin]
  * @zk-counters
- *  - 2 arith
- *  - 10 binary
+ *  - 1 arith
+ *  - 9 binary
  *  - 200 steps
  * @process-opcode
  *  - stack input: [shift, value]
  *  - stack output: [value >> shift (signed)]
  */
-; TODO: Adapt to multiplication
-; https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/evm/src/opcodes/functions.ts#L336
 opSAR:
     ; checks zk-counters
-    %MAX_CNT_ARITH - CNT_ARITH - 2 :JMPN(outOfCountersArith)
-    %MAX_CNT_BINARY - CNT_BINARY - 10 :JMPN(outOfCountersBinary)
-    %MAX_CNT_STEPS - STEP - 200 :JMPN(outOfCountersStep)
+    %MAX_CNT_ARITH - CNT_ARITH - 1      :JMPN(outOfCountersArith)
+    %MAX_CNT_BINARY - CNT_BINARY - 9   :JMPN(outOfCountersBinary)
+    %MAX_CNT_STEPS - STEP - 200         :JMPN(outOfCountersStep)
+
     ; check stack underflow
-    SP - 2          :JMPN(stackUnderflow)
-    SP - 1 => SP
-    $ => D          :MLOAD(SP--)    ; [shift (bits) => D]
-    ${D/8} => B                     ; [shift (bytes) => B]
-    32 => A
-    $ => A          :LT             ; if (shift (bytes) > 32) 1 => A, else 0 => A
-    1 => B
-    $ => B          :XOR            ; if (A == 1) 0 => B, else 1 => B
-    ${A * 256 + B * D} => D         ; if (shift (bytes) > 32) 256 => D, else D => D
-    $ => A          :MLOAD(SP)      ; [value => A]
-    ; CALL abs: Get absolute value (A) and sign (B)
-                    :CALL(abs)
-    ; CALL shr util (with arith)
-                    ; if more than 32 set to 32
-                    :CALL(SHRarithBit)
-    A => C                          ; [absolute value => C]
-    B => A                          ; [sign => A]
-    1 => B
-    $ => B          :XOR            ; if (sign negative (A == 1)) 0 => B, else 1 => B
-    B - 1           :JMPN(opSARNeg)  ; 0 negative, 1 positive
-    C               :MSTORE(SP++)   ; [absolute value => SP]
-    ; check stack overflow
-    1024 - SP       :JMPN(stackOverflow)
+    SP - 2              :JMPN(stackUnderflow)
+
     ; check out-of-gas
-    GAS-3 => GAS    :JMPN(outOfGas)
+    GAS - 3 => GAS      :JMPN(outOfGas)
+
+    ; read two items form the stack
+    SP - 1 => SP
+    $ => C          :MLOAD(SP--)    ; [shift (bits) => C]
+    $ => A          :MLOAD(SP)      ; [value => A]
+
+    ; call abs util. get absolute value (A) and sign (B)
+                    :CALL(abs) ; in: [A: value], out: [A: abs(A), B: sign(A)]]
+
+    A => D ; [abs(A) => D]
+    B => E ; [sign(A) => E]
+
+    ; check shift is less than 256 bits
+    C => B ; [shift (bits) => C]
+    256 => A
+    $               :LT, JMPC(maxShiftSAR)
+
+    ; prepare register to call util SHRarithBit
+    D => A ; [abs(a) => A]
+    C => D ; [shift (bits) => D]
+
+    ; call SHRarithBit util
+                    :CALL(SHRarithBit) ; [ A >> D => A]
+
+    ; check shifted result is greater than 0
+    0 => B
+    $               :EQ, JMPC(maxShiftSAR)
+
+    ; check sign negative or positive
+    ; if sign positive, return shifted result. sign negative, return -(shifted result)]
+    E - 1           :JMPN(finishOpSAR)
+
+    ; sign negative
+    A => B ; [shifted result => B]
+    0 => A
+
+    $ => A               :SUB   ; [0 - shifted result => A]
+
+finishOpSAR:
+    A               :MSTORE(SP++)   ; [(value >> shift (signed)) => SP]
+
+    ; continue read bytecode
                     :JMP(readCode)
 
-opSARNeg:
-    C => A                          ; [absolute value => A]
-    1 => B
-    $ => B          :LT             ; if (absolute value < 1) 1 => B, else 0 => B
-    ${A + B} => B                   ; TODO: This is UNSAFE
-    0 => A
-    $ => A          :SUB            ; 0 - (absolute value + B) => A
-    A               :MSTORE(SP++)
-    ; check stack overflow
-    1024 - SP       :JMPN(stackOverflow)
-    ; check out-of-gas
-    GAS-3 => GAS    :JMPN(outOfGas)
-                    :JMP(readCode)
+; return 0 if sign is positive. return %MAX_UINT_256 if sign is negative
+maxShiftSAR:
+    0 => D ; [sign positive: 0 => D]
+
+    ; check sign negative or positive
+    E - 1                   :JMPN(endMaxShiftSAR)
+    %MAX_UINT_256 => D ; [sign negative: MAX_UINT_256 => D]
+
+endMaxShiftSAR:
+    D                       :MSTORE(SP++) ; [(value >> shift (signed)) => SP]
+
+    ; continue read bytecode
+                            :JMP(readCode)

--- a/main/process-tx.zkasm
+++ b/main/process-tx.zkasm
@@ -32,6 +32,7 @@ processTx:
 
         ; Minimum of 100000 steps left to process a tx
         %MAX_CNT_STEPS - STEP - 100000 :JMPN(outOfCountersStep)
+
         ; Get sigDataSize
         $ => HASHPOS                     :MLOAD(sigDataSize)
 
@@ -49,7 +50,6 @@ processTx:
         E+1 => E                        :MSTORE(lastTxHashId)
 
         ; Check the signature
-
         $ => A                          :HASHKDIGEST(E)
         $ => B                          :MLOAD(txR)
         $ => C                          :MLOAD(txS)
@@ -441,6 +441,7 @@ callContract:
         0 => SP
 
         $ => A                          :MLOAD(txDestAddr)
+
         ; get contract length
         %SMT_KEY_SC_LENGTH => B
         0 => C

--- a/main/process-tx.zkasm
+++ b/main/process-tx.zkasm
@@ -464,8 +464,11 @@ callContract:
         E                               :MSTORE(contractHashId)
         E+1                             :MSTORE(nextHashPId)
 
+        ; check steps used by checkHashBytecodeLoop
+        ; compute steps that will be consumed by 'checkHashBytecodeLoop'
+        %MAX_CNT_STEPS - STEP - 2 * B   :JMPN(outOfCountersStep)
+
 checkHashBytecodeLoop:
-        %MAX_CNT_STEPS - STEP - 10 :JMPN(outOfCountersStep)
         B - 1 - HASHPOS                         :JMPN(checkHashBytecodeEnd) ; finish reading bytecode
         ${getBytecode(A, HASHPOS, 1)}           :HASHP(E) ; hash contract bytecode
                                                 :JMP(checkHashBytecodeLoop)

--- a/main/utils.zkasm
+++ b/main/utils.zkasm
@@ -27,9 +27,7 @@ VAR GLOBAL result
 ; @out B => Sign of A [1 if negative, 0 positive]
 abs:
     0 => B
-    ;TODO: fix `$ => B          :SLT,JMPC(absIsNeg)`
-    ;when zkproverjs has been updated
-    $ => B          :SLT,JMPC(absIsNeg)
+    $ => B          :SLT, JMPC(absIsNeg)
                     :RETURN
 
 absIsNeg:
@@ -40,7 +38,6 @@ absIsNeg:
                     :RETURN
 
 ; @info copy calldata A to ctxB SP = 1024
-; TODO: copy + 32 bytes
 copySP:
     RR              :MSTORE(tmpZkPC2)
     CTX             :MSTORE(currentCTX)
@@ -544,6 +541,8 @@ storeTmp:
 
 VAR GLOBAL tmpSHXZkPC
 VAR GLOBAL tmpSHXZkPC2
+
+;@info Shift right D bytes to A
 ;@in A - (A >> D)
 ;@in D - (A >> D) D bytes
 ;@out A - A >> D => A
@@ -1135,7 +1134,7 @@ utilMULMOD:
     ; remember that:
     ; result of mul is stored in: arithRes1(E) and arithOverflow(D)
 
-    ${(_mulMod / A) % (2 << 256)} => B   ; k.l
+    ${(_mulMod / A) % (1 << 256)} => B   ; k.l
     ${_mulMod % A} => C        ; mulModResult
     ${(B * A + C) >> 256} => D ; D1
     $               :MLOAD(arithRes1), ARITH

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xpolygonhermez/zkrom",
-  "version": "0.5.0.0",
+  "version": "0.5.0.1",
   "description": "zkROM source code",
   "main": "index.js",
   "scripts": {
@@ -32,8 +32,8 @@
     "yargs": "^17.5.1"
   },
   "devDependencies": {
-    "@0xpolygonhermez/zkevm-proverjs": "github:0xPolygonHermez/zkevm-proverjs#a99e77b070946c67c0ebdd296d1b5433a471df11",
-    "@0xpolygonhermez/zkevm-testvectors": "github:0xPolygonHermez/zkevm-testvectors#feature/benchmark",
+    "@0xpolygonhermez/zkevm-proverjs": "github:0xPolygonHermez/zkevm-proverjs#cedc278e4fbc93b84e8ea4008d9fa4ab590ce08f",
+    "@0xpolygonhermez/zkevm-testvectors": "github:0xPolygonHermez/zkevm-testvectors#develop",
     "chai": "^4.3.6",
     "chalk": "^3.0.0",
     "eslint": "^8.25.0",

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "yargs": "^17.5.1"
   },
   "devDependencies": {
-    "@0xpolygonhermez/zkevm-proverjs": "github:0xPolygonHermez/zkevm-proverjs#5cf87a1ea5f05dec875eb6d9934580a2f83c8438",
-    "@0xpolygonhermez/zkevm-testvectors": "github:0xPolygonHermez/zkevm-testvectors#develop",
+    "@0xpolygonhermez/zkevm-proverjs": "github:0xPolygonHermez/zkevm-proverjs#a99e77b070946c67c0ebdd296d1b5433a471df11",
+    "@0xpolygonhermez/zkevm-testvectors": "github:0xPolygonHermez/zkevm-testvectors#feature/benchmark",
     "chai": "^4.3.6",
     "chalk": "^3.0.0",
     "eslint": "^8.25.0",


### PR DESCRIPTION
This PR does the following:
- fix typo in file name `comparision.zkasm`
- add comments to all opcodes in `comparison.zkasm`
- fix `mulMOD` when taking 256 less significant bits of the result `mulmod`
- re-implement `sar` opcode to not have unsecure operations and optimize it
- precalculate steps counters in `checkHashBytecodeLoop` loop