### PR TITLE
Fix/counters

### DIFF
--- a/main/main.zkasm
+++ b/main/main.zkasm
@@ -70,14 +70,14 @@ skipSetGlobalExitRoot:
 
         ; Compute necessary keccak counters to finish batch
         $ => A          :MLOAD(batchL2DataLength)
-        ; Divide the total data length by 136 to obtain the keccak counter increment.
+        ; Divide the total data length + 1 by 136 to obtain the keccak counter increment.
         ; 136 is the value used by the prover to increment keccak counters
-        A                                       :MSTORE(arithA)
+        A + 1                                   :MSTORE(arithA)
         136                                     :MSTORE(arithB)
                                                 :CALL(divARITH)
         $ => B                                  :MLOAD(arithRes1)
         ; Compute minimum necessary keccaks to finish the batch
-        B + 1 + %MIN_CNT_KECCAK_BATCH               :MSTORE(cntKeccakPreProcess)
+        B + 1 + %MIN_CNT_KECCAK_BATCH           :MSTORE(cntKeccakPreProcess)
         %MAX_CNT_KECCAK_F - CNT_KECCAK_F => A
         $                                       :LT, JMPC(outOfCountersKeccak)
 


### PR DESCRIPTION
Small fix at keccac counter initial calculation:
At proverjs:
`ncCounter = Math.ceil((ctx.hashK[addr].data.length + 1) / 136)`

we forgot to add that +1 at rom
