### PR TITLE
`$` to `$$` & fix unsecure code

### DIFF
--- a/main/load-tx-rlp.zkasm
+++ b/main/load-tx-rlp.zkasm
@@ -332,10 +332,10 @@ vREADTx:
 ;; E - Handler error RLP fields
 ;;;;;;;;;
 handleOOCBatRLP:
-        ${eventLog(onError, OOCB)}
+        $${eventLog(onError, OOCB)}
                                         :JMP(handleOOCatRLP)
 handleOOCKatRLP:
-        ${eventLog(onError, OOCK)}
+        $${eventLog(onError, OOCK)}
                                         :JMP(handleOOCatRLP)
 handleOOCatRLP:
         $ => SR                         :MLOAD(batchSR)

--- a/main/main.zkasm
+++ b/main/main.zkasm
@@ -36,7 +36,7 @@ start: ; main zkROM entry point
 ;;     - load transaction count from system smart contract
 ;;     - compute keccaks needed to finish the batch
 ;;;;;;;;;;;;;;;;;;
-        ${eventLog(onStartBatch, C)}
+        $${eventLog(onStartBatch, C)}
 
         $ => A                                  :MLOAD(globalExitRoot)
         0 => B
@@ -132,7 +132,7 @@ txLoop:
 processTxEnd:
                         :CALL(updateSystemData)
 processTxFinished:
-        ${eventLog(onFinishTx)}
+        $${eventLog(onFinishTx)}
                         :JMP(txLoop)
 
 processTxsEnd:
@@ -193,7 +193,7 @@ processTxsEnd:
 
         $ => C                          :HASHKDIGEST(0)
         C                               :MSTORE(newAccInputHash)
-        ${eventLog(onFinishBatch)}
+        $${eventLog(onFinishBatch)}
 
 ;;;;;;;;;;;;;;;;;;
 ;; F - Finalize execution

--- a/main/opcodes/calldata-returndata-code.zkasm
+++ b/main/opcodes/calldata-returndata-code.zkasm
@@ -96,8 +96,6 @@ opCALLDATASIZEdep:
     %CALLDATA_OFFSET - SP       :JMPN(stackOverflow)
                     :JMP(readCode)
 
-
-; // TODO: if ins deployment only write 0
 /**
  * @link [https://www.evm.codes/#37?fork=berlin]
  * @zk-counters
@@ -127,7 +125,20 @@ opCALLDATACOPY:
     C               :MSTORE(lastMemLength)
     ; check out-of-gas
     GAS - %GAS_FASTEST_STEP => GAS  :JMPN(outOfGas)
-    GAS - ${3*((C+31)/32)} => GAS    :JMPN(outOfGas)
+    ;${3*((C+31)/32)}
+    ;(C+31)/32 => A
+    C+31 => A
+    A               :MSTORE(arithA)
+    32              :MSTORE(arithB)
+                    :CALL(divARITH); in: [arithA, arithB] out: [arithRes1: arithA/arithB, arithRes2: arithA%arithB]
+    $ => A          :MLOAD(arithRes1)
+    ; Mul operation with Arith
+    ; 3*A
+    3               :MSTORE(arithA)
+    A               :MSTORE(arithB)
+                    :CALL(mulARITH); in: [arithA, arithB] out: [arithRes1: arithA*arithB]
+    $ => A          :MLOAD(arithRes1)
+    GAS - A => GAS  :JMPN(outOfGas)
                     :CALL(saveMem); in: [lastMemOffset, lastMemLength]
     ; save current stack pointer
     SP              :MSTORE(SPw)
@@ -313,7 +324,7 @@ opCODECOPY:
     SP - 3          :JMPN(stackUnderflow)
     ; if is a create, copy from calldata
     $ => A          :MLOAD(isCreateContract)
-    0 - A           :JMPN(opCALLDATACOPY) ; //TODO: delegateCall ? use of storageAddr? same in process_tx ?
+    0 - A           :JMPN(opCALLDATACOPY)
     SP - 1 => SP
     $ => C          :MLOAD(SP--); [destOffset => C]
     $ => D          :MLOAD(SP--); [offset => D]

--- a/main/opcodes/create-terminate-context.zkasm
+++ b/main/opcodes/create-terminate-context.zkasm
@@ -978,7 +978,7 @@ opREVERT:
                     :CALL(saveMem); in: [lastMemOffset, lastMemLength]
     ; check if first context
     $ => B          :MLOAD(originCTX)
-    ${eventLog(onError, revert)}
+    $${eventLog(onError, revert)}
     0               :MSTORE(gasRefund)
     ; if origin ctx is 0, end tx
     B - 1           :JMPN(handleGas)

--- a/main/opcodes/logs.zkasm
+++ b/main/opcodes/logs.zkasm
@@ -162,14 +162,14 @@ opLOGLoop:
     C - 32          :JMPN(opLOGFinal)
     ; load next 32 bytes
                     :CALL(MLOAD32); in: [E: offset] out: [A: value]
-    ${storeLog(B, 0, A)} ; storeLog(indexLog, isTopic, bytesToStore)
+    $${storeLog(B, 0, A)} ; storeLog(indexLog, isTopic, bytesToStore)
     C - 32 => C
                     :JMP(opLOGLoop)
 
 opLOGFinal:
     ; load last C bytes
                     :CALL(MLOADX); in: [E: offset, C: length] out: [A: value, E: new offset]
-    ${storeLog(B, 0, A)}; storeLog(indexLog, isTopic, bytesToStore)
+    $${storeLog(B, 0, A)}; storeLog(indexLog, isTopic, bytesToStore)
 
 opSaveTopicsInit:
     ; save topics
@@ -185,6 +185,6 @@ opSaveTopicsLoop:
     ; check out-of-gas
     GAS - %LOG_TOPIC_GAS => GAS    :JMPN(outOfGas)
     $ => C              :MLOAD(SP)   ; [topic => C]
-    ${storeLog(B, 1, C)}     ; storeLog(indexLog, isTopic, bytesToStore)
+    $${storeLog(B, 1, C)}     ; storeLog(indexLog, isTopic, bytesToStore)
     A - 1 =>  A
                         :JMP(opSaveTopicsLoop)

--- a/main/opcodes/logs.zkasm
+++ b/main/opcodes/logs.zkasm
@@ -170,6 +170,7 @@ opLOGFinal:
     ; load last C bytes
                     :CALL(MLOADX); in: [E: offset, C: length] out: [A: value, E: new offset]
     $${storeLog(B, 0, A)}; storeLog(indexLog, isTopic, bytesToStore)
+                    :JMP(opSaveTopicsInit) ; instruction added to allow executing $$ function
 
 opSaveTopicsInit:
     ; save topics

--- a/main/precompiled/identity.zkasm
+++ b/main/precompiled/identity.zkasm
@@ -7,8 +7,14 @@ IDENTITY:
 
     GAS - %IDENTITY_GAS => GAS :JMPN(outOfGas)
     $ => C          :MLOAD(argsLengthCall)
-    ${(C+31)/32} => A
-    GAS - %IDENTITY_WORD_GAS*A => GAS:JMPN(outOfGas)
+    ;(C+31)/32 => A
+    C + 31 => A
+    A               :MSTORE(arithA)
+    32              :MSTORE(arithB)
+                    :CALL(divARITH); in: [arithA, arithB] out: [arithRes1: arithA/arithB, arithRes2: arithA%arithB]
+    $ => A          :MLOAD(arithRes1)
+
+    GAS - %IDENTITY_WORD_GAS*A => GAS   :JMPN(outOfGas)
     CTX             :MSTORE(currentCTX)
     CTX => A
     $ => CTX        :MLOAD(originCTX)

--- a/main/precompiled/pre-ecrecover.zkasm
+++ b/main/precompiled/pre-ecrecover.zkasm
@@ -32,7 +32,6 @@ funcECRECOVER:
     0 - B                               :JMPN(endECRECOVER)
     ; prepare return data
     $ => E                              :MLOAD(retCallOffset)
-    ; $ => C                            :MLOAD(retCallLength) ; always 32
     $ => C                              :MLOAD(originCTX)
     C - 1                               :JMPN(handleGas)
     C => CTX

--- a/main/process-tx.zkasm
+++ b/main/process-tx.zkasm
@@ -602,5 +602,5 @@ handleIntrinsicError:
 
 ;; handle error no more bytecode to read
 defaultOpCode:
-        ${eventLog(onOpcode(0))}
+        $${eventLog(onOpcode(0))}
                                         :JMP(opSTOP)

--- a/main/process-tx.zkasm
+++ b/main/process-tx.zkasm
@@ -20,7 +20,7 @@ processTx:
 ;; A - Verify ecdsa signature
 ;;;;;;;;;;;;;;;;;;
 
-        ${eventLog(onProcessTx)}
+        $${eventLog(onProcessTx)}
 
 ;;;;;;;;;
 ;; Store init state
@@ -371,7 +371,7 @@ readDeployBytecode:
         HASHPOS + PC => HASHPOS
         $ => E                          :MLOAD(batchHashDataId)
         $ => RR                         :HASHK1(E)
-        ${eventLog(onOpcode(RR))}
+        $${eventLog(onOpcode(RR))}
         PC + 1 => PC
                                         :JMP(@mapping_opcodes + RR)
 
@@ -390,7 +390,7 @@ readDeployBytecodeCreate:
         31 => D
                                         :CALL(SHRarith)
         A => RR
-        ${eventLog(onOpcode(RR))}
+        $${eventLog(onOpcode(RR))}
         PC + 1 => PC
                                         :JMP(@mapping_opcodes + RR)
 
@@ -469,7 +469,7 @@ readByteCode:
         B - PC - 1                      :JMPN(defaultOpCode) ; no bytecode treated as 0x00
         PC => HASHPOS
         $ => RR                         :HASHP1(E)
-        ${eventLog(onOpcode(RR))}
+        $${eventLog(onOpcode(RR))}
         PC + 1 => PC
                                         :JMP(@mapping_opcodes + RR)
 
@@ -576,25 +576,25 @@ sendGasSeq:
 
 ;; handle invalid transaction due to intrinsic checks
 invalidIntrinsicTxSignature:
-        ${eventLog(onError, intrinsic_invalid_signature)}
+        $${eventLog(onError, intrinsic_invalid_signature)}
                         :JMP(handleIntrinsicError)
 invalidIntrinsicTxChainId:
-        ${eventLog(onError, intrinsic_invalid_chain_id)}
+        $${eventLog(onError, intrinsic_invalid_chain_id)}
                         :JMP(handleIntrinsicError)
 invalidIntrinsicTxNonce:
-        ${eventLog(onError, intrinsic_invalid_nonce)}
+        $${eventLog(onError, intrinsic_invalid_nonce)}
                         :JMP(handleIntrinsicError)
 invalidIntrinsicTxGasLimit:
-        ${eventLog(onError, intrinsic_invalid_gas_limit)}
+        $${eventLog(onError, intrinsic_invalid_gas_limit)}
                         :JMP(handleIntrinsicError)
 invalidIntrinsicTxBalance:
-        ${eventLog(onError, intrinsic_invalid_balance)}
+        $${eventLog(onError, intrinsic_invalid_balance)}
                         :JMP(handleIntrinsicError)
 invalidIntrinsicBatchGasLimit:
-        ${eventLog(onError, intrinsic_invalid_batch_gas_limit)}
+        $${eventLog(onError, intrinsic_invalid_batch_gas_limit)}
                         :JMP(handleIntrinsicError)
 invalidIntrinsicTxSenderCode:
-        ${eventLog(onError, intrinsic_invalid_sender_code)}
+        $${eventLog(onError, intrinsic_invalid_sender_code)}
                         :JMP(handleIntrinsicError)
 handleIntrinsicError:
         $ => SR                         :MLOAD(originSR)

--- a/main/utils.zkasm
+++ b/main/utils.zkasm
@@ -685,49 +685,49 @@ SHLarithfinal:
                             :JMP(RR)
 
 outOfCountersStep:
-    ${eventLog(onError, OOCS)}
+    $${eventLog(onError, OOCS)}
                     :JMP(handleBatchError)
 outOfCountersKeccak:
-    ${eventLog(onError, OOCK)}
+    $${eventLog(onError, OOCK)}
                     :JMP(handleBatchError)
 outOfCountersBinary:
-    ${eventLog(onError, OOCB)}
+    $${eventLog(onError, OOCB)}
                     :JMP(handleBatchError)
 outOfCountersMemalign:
-    ${eventLog(onError, OOCM)}
+    $${eventLog(onError, OOCM)}
                     :JMP(handleBatchError)
 outOfCountersArith:
-    ${eventLog(onError, OOCA)}
+    $${eventLog(onError, OOCA)}
                     :JMP(handleBatchError)
 outOfCountersPadding:
-    ${eventLog(onError, OOCPA)}
+    $${eventLog(onError, OOCPA)}
                     :JMP(handleBatchError)
 outOfCountersPoseidon:
-    ${eventLog(onError, OOCPO)}
+    $${eventLog(onError, OOCPO)}
                     :JMP(handleBatchError)
 outOfGas:
-    ${eventLog(onError, OOG)}
+    $${eventLog(onError, OOG)}
                     :JMP(handleError)
 invalidJump:
-    ${eventLog(onError, invalid)}
+    $${eventLog(onError, invalid)}
                     :JMP(handleError)
 invalidProcess:
-    ${eventLog(onError, invalid)}
+    $${eventLog(onError, invalid)}
                     :JMP(handleError)
 stackUnderflow:
-    ${eventLog(onError, underflow)}
+    $${eventLog(onError, underflow)}
                     :JMP(handleError)
 stackOverflow:
-    ${eventLog(onError, overflow)}
+    $${eventLog(onError, overflow)}
                     :JMP(handleError)
 deployAddressCollision:
-    ${eventLog(onError, invalid)}
+    $${eventLog(onError, invalid)}
                     :JMP(handleError)
 invalidStaticTx:
-    ${eventLog(onError, invalid)}
+    $${eventLog(onError, invalid)}
                     :JMP(handleError)
 invalidCodeSize:
-    ${eventLog(onError, invalid)}
+    $${eventLog(onError, invalid)}
                     :JMP(handleError)
 handleError:
     ;revert all state changes
@@ -752,8 +752,8 @@ handleError:
 
 handleBatchError:
     $ => SR         :MLOAD(batchSR)
-    ${eventLog(onFinishTx)}
-    ${eventLog(onFinishBatch)}
+    $${eventLog(onFinishTx)}
+    $${eventLog(onFinishBatch)}
                     :JMP(processTxsEnd)
 
 firstContextInvalid:
@@ -1033,7 +1033,7 @@ hashPoseidonEnd:
     $ => E          :MLOAD(tmpContractHashId)
     HASHPOS         :HASHPLEN(E)
     $ => D          :HASHPDIGEST(E)
-    ${saveContractBytecode(E)}
+    $${saveContractBytecode(E)}
 
 hashPoseidonReturn:
     $ => RR         :MLOAD(tmpZkPC2)

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "yargs": "^17.5.1"
   },
   "devDependencies": {
-    "@0xpolygonhermez/zkevm-proverjs": "github:0xPolygonHermez/zkevm-proverjs#1252c73125b24f28f38bbe7075895aa0a2a12eb9",
+    "@0xpolygonhermez/zkevm-proverjs": "github:0xPolygonHermez/zkevm-proverjs#feature/clean-code-main-exec",
     "@0xpolygonhermez/zkevm-testvectors": "github:0xPolygonHermez/zkevm-testvectors#v0.5.1.0",
     "chai": "^4.3.6",
     "chalk": "^3.0.0",


### PR DESCRIPTION
This PR does the following:
- Fix unsecure computation in `IDENTITY` & `CALLDATA`
- Move all code execution from `$` to `$$`