### PR TITLE
Audit jan fixes

### DIFF
--- a/counters/tests/opBLOCKHASH.zkasm
+++ b/counters/tests/opBLOCKHASH.zkasm
@@ -4,8 +4,7 @@ start:
     1000000 => GAS
 
 operation:
-    1 => D
-    2       :HASHK(0)
+    2       :HASHK1(0)
     10      :MSTORE(txCount)
     1       :MSTORE(SP++)
             :JMP(opBLOCKHASH)

--- a/counters/tests/opSHA3.zkasm
+++ b/counters/tests/opSHA3.zkasm
@@ -4,8 +4,7 @@ start:
     1000000 => GAS
 
 operation:
-    1 => D
-    2       :HASHK(0)
+    2       :HASHK1(0)
     2000    :MSTORE(SP++)
     100     :MSTORE(SP++)
             :JMP(opSHA3)

--- a/main/constants.zkasm
+++ b/main/constants.zkasm
@@ -30,9 +30,6 @@ CONST %SMT_KEY_TOUCHED_SLOTS = 6
 CONST %BASE_TX_GAS = 21000
 CONST %BASE_TX_DEPLOY_GAS = 53000
 CONST %SLOAD_GAS = 100
-CONST %SSTORE_SET_GAS = 20000
-CONST %SSTORE_RESET_GAS = 2900
-CONST %SSTORE_CLEARS_SCHEDULE = 15000
 CONST %GAS_QUICK_STEP = 2
 CONST %GAS_FASTEST_STEP = 3
 CONST %GAS_FAST_STEP = 5
@@ -58,12 +55,18 @@ CONST %RETURN_GAS_COST = 200; 200 * returned_code_size
 CONST %CREATE_GAS = 32000
 CONST %CREATE_2_GAS = 32000
 CONST %SENDALL_GAS = 5000
+CONST %LOG_DATA_GAS = 8
 ; sstore
 CONST %SSTORE_ENTRY_EIP_2200_GAS = 2300 ; Minimum gas required to be present for an SSTORE call, not consumed
 CONST %SSTORE_SET_EIP_2200_GAS = 20000 ; Once per SSTORE operation from clean zero to non-zero
 CONST %COLD_SLOAD_COST = 2100 ; Cost of using a cols memory slot
 CONST %COLD_SLOAD_COST_RED = 2000 ; Cost of using a cols memory slot reduced
 CONST %SSTORE_DYNAMIC_GAS = 100
+CONST %SSTORE_SET_GAS = 20000
+CONST %SSTORE_SET_GAS_RED = 19900 ; sstore gas cost reduced base_dynamic_gas(original_value == 0) - base_dynamic_gas(100)
+CONST %SSTORE_RESET_GAS = 2900
+CONST %SSTORE_RESET_GAS_RED = 2800 ; sstore update gas cost reduced base_dynamic_gas(original_value == 0) - base_dynamic_gas(100)
+CONST %SSTORE_CLEARS_SCHEDULE = 15000
 ; COUNTERS
 CONST %MIN_STEPS_FINISH_BATCH = 200 ; min steps to finish tx
 CONST %TOTAL_STEPS = 2**23

--- a/main/constants.zkasm
+++ b/main/constants.zkasm
@@ -48,7 +48,7 @@ CONST %LOG_GAS = 375 ; Per LOG* operation.
 CONST %LOG_TOPIC_GAS = 375 ; Per LOG topic operation.
 CONST %JUMP_DEST_GAS = 1 ; Once per JUMPDEST operation.
 CONST %WARM_STORGE_READ_GAS = 100 ; WarmStorageReadCostEIP2929
-CONST %COLD_ACCOUNT_ACCESS_COST_RED = 2500 ; ColdAccountAccessCostEIP2929 reduced(2600)
+CONST %COLD_ACCOUNT_ACCESS_COST_REDUCED = 2500 ; ColdAccountAccessCostEIP2929 reduced(2600)
 CONST %COLD_ACCOUNT_ACCESS_COST = 2600 ; ColdAccountAccessCostEIP2929
 CONST %EXP_BYTE_GAS = 50 ; was raised to 50 during Eip158 (Spurious Dragon)
 CONST %RETURN_GAS_COST = 200; 200 * returned_code_size
@@ -60,12 +60,12 @@ CONST %LOG_DATA_GAS = 8
 CONST %SSTORE_ENTRY_EIP_2200_GAS = 2300 ; Minimum gas required to be present for an SSTORE call, not consumed
 CONST %SSTORE_SET_EIP_2200_GAS = 20000 ; Once per SSTORE operation from clean zero to non-zero
 CONST %COLD_SLOAD_COST = 2100 ; Cost of using a cols memory slot
-CONST %COLD_SLOAD_COST_RED = 2000 ; Cost of using a cols memory slot reduced
+CONST %COLD_SLOAD_COST_REDUCED = 2000 ; Cost of using a cols memory slot reduced
 CONST %SSTORE_DYNAMIC_GAS = 100
 CONST %SSTORE_SET_GAS = 20000
-CONST %SSTORE_SET_GAS_RED = 19900 ; sstore gas cost reduced base_dynamic_gas(original_value == 0) - base_dynamic_gas(100)
+CONST %SSTORE_SET_GAS_REDUCED = 19900 ; sstore gas cost reduced base_dynamic_gas(original_value == 0) - base_dynamic_gas(100)
 CONST %SSTORE_RESET_GAS = 2900
-CONST %SSTORE_RESET_GAS_RED = 2800 ; sstore update gas cost reduced base_dynamic_gas(original_value == 0) - base_dynamic_gas(100)
+CONST %SSTORE_RESET_GAS_REDUCED = 2800 ; sstore update gas cost reduced base_dynamic_gas(original_value == 0) - base_dynamic_gas(100)
 CONST %SSTORE_CLEARS_SCHEDULE = 15000
 ; COUNTERS
 CONST %MIN_STEPS_FINISH_BATCH = 200 ; min steps to finish tx

--- a/main/opcodes/calldata-returndata-code.zkasm
+++ b/main/opcodes/calldata-returndata-code.zkasm
@@ -381,7 +381,7 @@ opEXTCODESIZE:
     $ => A          :MLOAD(SP), CALL(maskAddress); [address => A]; in: [A: address] out: [A: masked address]
                     :CALL(isColdAddress); in: [A: address] out: [D: 0 if warm, 1 if cold]
     ; check out-of-gas
-    GAS - %WARM_STORGE_READ_GAS - D * %COLD_ACCOUNT_ACCESS_COST_RED => GAS    :JMPN(outOfGas)
+    GAS - %WARM_STORGE_READ_GAS - D * %COLD_ACCOUNT_ACCESS_COST_REDUCED => GAS    :JMPN(outOfGas)
     ; set key for smt smart contract length query
     %SMT_KEY_SC_LENGTH => B
     0 => C
@@ -418,7 +418,7 @@ opEXTCODECOPY:
                     :CALL(isColdAddress); in: [A: address] out: [D: 0 if warm, 1 if cold]
 
     ; check out-of-gas
-    GAS - %WARM_STORGE_READ_GAS - D * %COLD_ACCOUNT_ACCESS_COST_RED => GAS            :JMPN(outOfGas)
+    GAS - %WARM_STORGE_READ_GAS - D * %COLD_ACCOUNT_ACCESS_COST_REDUCED => GAS            :JMPN(outOfGas)
                     :CALL(opEXTCODECOPYLoadBytecode)
     $ => C          :MLOAD(SP+2); [destOffset => C]
     $ => D          :MLOAD(SP+1); [offset => D]
@@ -646,7 +646,7 @@ opEXTCODEHASH:
     $ => A          :MLOAD(SP), CALL(maskAddress); [address => A]; in: [A: address] out: [A: masked address]
                     :CALL(isColdAddress); in: [A: address] out: [D: 0 if warm, 1 if cold]
     ; check out-of-gas
-    GAS - %WARM_STORGE_READ_GAS - D * %COLD_ACCOUNT_ACCESS_COST_RED => GAS    :JMPN(outOfGas)
+    GAS - %WARM_STORGE_READ_GAS - D * %COLD_ACCOUNT_ACCESS_COST_REDUCED => GAS    :JMPN(outOfGas)
     ; set key for smt smart contract code hash query
     %SMT_KEY_SC_CODE => B
     0 => C

--- a/main/opcodes/context-information.zkasm
+++ b/main/opcodes/context-information.zkasm
@@ -73,7 +73,7 @@ opBALANCE:
     $ => D          :SLOAD
     D               :MSTORE(SP-1), CALL(isColdAddress); [balance(D) => SP]; in: [A: address] out: [D: 0 if warm, 1 if cold]
     ; check out-of-gas
-    GAS - %WARM_STORGE_READ_GAS - D * %COLD_ACCOUNT_ACCESS_COST_RED => GAS    :JMPN(outOfGas, readCode)
+    GAS - %WARM_STORGE_READ_GAS - D * %COLD_ACCOUNT_ACCESS_COST_REDUCED => GAS    :JMPN(outOfGas, readCode)
 
 /**
  * @link [https://www.evm.codes/#32?fork=berlin]

--- a/main/opcodes/create-terminate-context.zkasm
+++ b/main/opcodes/create-terminate-context.zkasm
@@ -226,7 +226,7 @@ opCALL2:
 
     ;gas_cost = memory_expansion_cost + code_execution_cost + address_access_cost + positive_value_cost + value_to_empty_account_cost
     ; Calculate address_access_cost: 100 for warm account, 2600 for cold account
-    GAS - %WARM_STORGE_READ_GAS - D * %COLD_ACCOUNT_ACCESS_COST_RED => GAS :JMPN(outOfGas)
+    GAS - %WARM_STORGE_READ_GAS - D * %COLD_ACCOUNT_ACCESS_COST_REDUCED => GAS :JMPN(outOfGas)
     ; Calculate positive_value_cost, if value call > 0 -> 9000
     $ => B          :MLOAD(valueCall)
     0 => A
@@ -339,7 +339,7 @@ opCALLCODE:
 
     ;gas_cost = memory_expansion_cost + code_execution_cost + address_access_cost + positive_value_cost
     ; Calculate address_access_cost: 100 for warm account, 2600 for cold account
-    GAS - %WARM_STORGE_READ_GAS - D * %COLD_ACCOUNT_ACCESS_COST_RED => GAS    :JMPN(outOfGas)
+    GAS - %WARM_STORGE_READ_GAS - D * %COLD_ACCOUNT_ACCESS_COST_REDUCED => GAS    :JMPN(outOfGas)
     ; Calculate positive_value_cost, if value call > 0 -> 9000
     $ => B                   :MLOAD(valueCall)
     0 => A
@@ -601,7 +601,7 @@ opDELEGATECALL:
     $ => A                   :MLOAD(addrCall)
                              :CALL(isColdAddress); in: [A: address] out: [D: 0 if warm, 1 if cold]
     ;gas_cost = base_gas + gas_sent_with_call
-    GAS - %WARM_STORGE_READ_GAS - D * %COLD_ACCOUNT_ACCESS_COST_RED => GAS    :JMPN(outOfGas)
+    GAS - %WARM_STORGE_READ_GAS - D * %COLD_ACCOUNT_ACCESS_COST_REDUCED => GAS    :JMPN(outOfGas)
 
     ; transition to new CTX
     $ => C          :MLOAD(txSrcAddr)
@@ -815,7 +815,7 @@ opSTATICCALL:
     ; check if an address is cold. If it is, add it to the touched tree
     $ => A          :MLOAD(addrCall), CALL(isColdAddress); in: [A: address] out: [D: 0 if warm, 1 if cold]
     ;gas_cost = base_gas + gas_sent_with_call
-    GAS - %WARM_STORGE_READ_GAS - D * %COLD_ACCOUNT_ACCESS_COST_RED => GAS    :JMPN(outOfGas)
+    GAS - %WARM_STORGE_READ_GAS - D * %COLD_ACCOUNT_ACCESS_COST_REDUCED => GAS    :JMPN(outOfGas)
 
     ; setup vars for next CTX
     $ => D          :MLOAD(storageAddr)

--- a/main/opcodes/flow-control.zkasm
+++ b/main/opcodes/flow-control.zkasm
@@ -20,7 +20,7 @@ opJUMP:
     GAS - %GAS_MID_STEP => GAS      :JMPN(outOfGas)
 
     ; Check PC is a JUMPDEST
-    $ => B                         :MLOAD(SP), JMP(checkJumpDest); [counter => PC]
+    $ => A                         :MLOAD(SP), JMP(checkJumpDest); [counter => PC]
 /**
  * @link [https://www.evm.codes/#57?fork=berlin]
  * @zk-counters
@@ -41,36 +41,36 @@ opJUMPI:
     0 => A
     $                               :EQ, JMPC(readCode)
     ; Check PC is a JUMPDEST
-    $ => B                          :MLOAD(SP+1), JMP(checkJumpDest); [counter => PC]
+    $ => A                          :MLOAD(SP+1), JMP(checkJumpDest); [counter => PC]
 
 checkJumpDest:
     ; if it is a deploy we have to check the data from the calldata (not the bytecode)
-    $ => A                          :MLOAD(isCreateContract), JMPNZ(checkJumpDestDeployment)
-    $ => A                          :MLOAD(bytecodeLength)
-    $                               :LT,JMPC(invalidJump)
+    $ => B                          :MLOAD(isCreateContract), JMPNZ(checkJumpDestDeployment)
+    $ => B                          :MLOAD(bytecodeLength)
+    $                               :LT,JMPNC(invalidJump)
+    A => B
     B => PC
     B => HASHPOS
     ; get hashP address pointer where contract bytecode is stored
     $ => E                          :MLOAD(contractHashId)
     $ => A                          :HASHP1(E)
     ; check if is a jumpDest (0x5B)
-    0x5B => B
-    $                               :EQ, JMPC(readCode, invalidJump)
+    A - 0x5B                        :JMPZ(readCode, invalidJump)
+
 checkJumpDestDeployment:
     ; check jumpDest from calldata
-    $ => A                          :MLOAD(isCreate), JMPNZ(checkJumpDestDeploymentCreate)
+    $ => B                          :MLOAD(isCreate), JMPNZ(checkJumpDestDeploymentCreate)
     ; get position where data starts in the tx
     $ => HASHPOS                    :MLOAD(dataStarts)
-    ; add PC to data starts to point the bytes to read for the push
-    B => PC
+    ; add PC to data starts to point the bytes to read for the jumpdest
+    A => PC
     HASHPOS + PC => HASHPOS
     ; get memory pointer for hashing
     $ => E                          :MLOAD(batchHashDataId)
-    ; set number of bytes to hashK at D
+    ; set number of bytes to hashK
     $ => A                          :HASHK1(E)
     ; check if is a jumpDest (0x5B)
-    0x5B => B
-    $                               :EQ, JMPC(readCode, invalidJump)
+    A - 0x5B                        :JMPZ(readCode, invalidJump)
 
 checkJumpDestDeploymentCreate:
     ; get bytes from previous context memory
@@ -78,14 +78,13 @@ checkJumpDestDeploymentCreate:
     ; get offset call position
     $ => E                          :MLOAD(argsOffsetCall)
     ; increase current program counter (PC) to offset for getting pushed bytes to read
-    B => PC
+    A => PC
     E + PC => E
     ; set bytes to read from memory at C
     1 => C                          :CALL(MLOADX); in: [E: offset, C: length] out: [A: value, E: new offset]
     $ => CTX                        :MLOAD(currentCTX)
-    31 => D                         :CALL(SHRarith); in: [A: value, D: #bytes to right shift] out: [A: shifted result]
     ; check if is a jumpDest (0x5B)
-    0x5B => B
+    0x5b00000000000000000000000000000000000000000000000000000000000000n => B
     $                               :EQ, JMPC(readCode, invalidJump)
 
 /**

--- a/main/opcodes/logs.zkasm
+++ b/main/opcodes/logs.zkasm
@@ -31,7 +31,7 @@ opLOG0:
     ; store number of topics
     0                   :MSTORE(numTopics)
     ; calculate data size gas cost => lastMemLength * 8
-    8                   :MSTORE(arithA)
+    %LOG_DATA_GAS       :MSTORE(arithA)
     C                   :MSTORE(arithB), CALL(mulARITH); in: [arithA, arithB] out: [arithRes1: arithA*arithB]
     $ => B              :MLOAD(arithRes1)
     GAS => A

--- a/main/opcodes/stack-operations.zkasm
+++ b/main/opcodes/stack-operations.zkasm
@@ -180,13 +180,13 @@ opAuxPUSHBloop:
     HASHPOS + PC => HASHPOS
     PC + 1 => PC
     ; get memory pointer for hashing
-    1 => D
     $ => E                          :MLOAD(batchHashDataId)
-    $ => B                          :HASHK(E)
+    $ => B                          :HASHK1(E)
     ; accumulate hash value
     A + B => A
     ; decrease length for loop
     C - 1 => C                      :JMPN(opAuxPUSHBend)
+    1 => D
                                     :CALL(SHLarith); in: [A: value, D: #bytes to left shift] out: [A: shifted result]
                                     :JMP(opAuxPUSHBloop)
 

--- a/main/opcodes/stack-operations.zkasm
+++ b/main/opcodes/stack-operations.zkasm
@@ -186,8 +186,7 @@ opAuxPUSHBloop:
     A + B => A
     ; decrease length for loop
     C - 1 => C                      :JMPN(opAuxPUSHBend)
-    1 => D
-                                    :CALL(SHLarith); in: [A: value, D: #bytes to left shift] out: [A: shifted result]
+    1 => D                          :CALL(SHLarith); in: [A: value, D: #bytes to left shift] out: [A: shifted result]
                                     :JMP(opAuxPUSHBloop)
 
 opAuxPUSHBend:

--- a/main/opcodes/storage-memory.zkasm
+++ b/main/opcodes/storage-memory.zkasm
@@ -162,7 +162,7 @@ opSLOAD:
     ; set key(C) as warmed storage for address(A)
     E               :MSTORE(SP++), CALL(isColdSlot); [value(E) => SP]
     ; check out-of-gas
-    GAS - %SLOAD_GAS - A * %COLD_SLOAD_COST_RED => GAS    :JMPN(outOfGas, readCode)
+    GAS - %SLOAD_GAS - A * %COLD_SLOAD_COST_REDUCED => GAS    :JMPN(outOfGas, readCode)
 
 VAR GLOBAL tmpVarCsstore
 /**
@@ -252,7 +252,7 @@ opSSTOREdifAB:
     $ => A          :EQ, JMPNC(opSSTOREdifA2)
     ; if orig_val == 0
     $ => A          :MLOAD(gasRefund)
-    A + %SSTORE_SET_GAS_RED => A  :MSTORE(gasRefund), JMP(opSSTOREend)
+    A + %SSTORE_SET_GAS_REDUCED => A  :MSTORE(gasRefund), JMP(opSSTOREend)
 
 opSSTOREdifA1:
     ; if orig_val != 0
@@ -277,7 +277,7 @@ opSSTOREdifA2:
     ; if orig_val != 0
     ; compute gas refund
     $ => A          :MLOAD(gasRefund)
-    A + %SSTORE_RESET_GAS_RED => A   :MSTORE(gasRefund), JMP(opSSTOREend)
+    A + %SSTORE_RESET_GAS_REDUCED => A   :MSTORE(gasRefund), JMP(opSSTOREend)
 
 opSSTOREdifB:
     ; if orig_val != 0

--- a/main/opcodes/storage-memory.zkasm
+++ b/main/opcodes/storage-memory.zkasm
@@ -58,7 +58,7 @@ opMLOAD:
     B               :MSTORE(bytesToStore)
     ; store lastMemOffset for memory expansion gas cost
     E               :MSTORE(lastMemOffset), CALL(MSTORE32); in: [bytesToStore, E: offset] out: [A: value]
-    ; store lastMemOffset for memory expansion gas cost
+    ; store lastMemLength for memory expansion gas cost
     32              :MSTORE(lastMemLength), CALL(saveMem); in: [lastMemOffset, lastMemLength]
                     :JMP(readCode)
 
@@ -252,7 +252,7 @@ opSSTOREdifAB:
     $ => A          :EQ, JMPNC(opSSTOREdifA2)
     ; if orig_val == 0
     $ => A          :MLOAD(gasRefund)
-    A + 19900 => A  :MSTORE(gasRefund), JMP(opSSTOREend)
+    A + %SSTORE_SET_GAS_RED => A  :MSTORE(gasRefund), JMP(opSSTOREend)
 
 opSSTOREdifA1:
     ; if orig_val != 0
@@ -277,7 +277,7 @@ opSSTOREdifA2:
     ; if orig_val != 0
     ; compute gas refund
     $ => A          :MLOAD(gasRefund)
-    A + 2800 => A   :MSTORE(gasRefund), JMP(opSSTOREend)
+    A + %SSTORE_RESET_GAS_RED => A   :MSTORE(gasRefund), JMP(opSSTOREend)
 
 opSSTOREdifB:
     ; if orig_val != 0

--- a/main/utils.zkasm
+++ b/main/utils.zkasm
@@ -180,7 +180,6 @@ MSTORE32:
     B               :MSTORE(tmpVarBmstore)
     C               :MSTORE(tmpVarCmstore)
     D               :MSTORE(tmpVarDmstore)
-    E               :MSTORE(tmpVarEmstore)
     ; check offset is lower than max memory
     E => A
     %MEMORY_LENGTH => B

--- a/main/utils.zkasm
+++ b/main/utils.zkasm
@@ -316,7 +316,7 @@ MLOAD32:
     $               :LT,JMPC(initMLOAD, errorMLOADMSTORE)
 
 initMLOAD:
-    zkPC+1 => RR    :JMP(offsetUtil); in: [A: offset] out: [E: offset/32, C: offset%32]
+                    :CALL(offsetUtil); in: [A: offset] out: [E: offset/32, C: offset%32]
     ; if C has value, bytes splitted in two memory slots
     C               :JMPNZ(memAlignOptionMLOAD)
     ; load memory from one slot


### PR DESCRIPTION
Fixes from https://github.com/spearbit-audits/review-polygon-zkevm-jan/pull/1
And others:
- Improve performance of jumpDest check -> https://github.com/spearbit-audits/review-polygon-zkevm-jan/issues/9
- Comments fixes
- Updated hask to hask1 at blockhash and sha3
- Moved some hardcoded values to constants
- Fixed bug at check jumpd dest (bad behaviour when checkJumpDest = bytecodelength) -> https://github.com/spearbit-audits/review-polygon-zkevm-jan/issues/7
- Remove unnecessary mstore of E at MSTORE32 -> https://github.com/spearbit-audits/review-polygon-zkevm-jan/issues/10