### PR TITLE
fix zk-counters checks with :LT

### DIFF
--- a/counters/tests/opSHA3.zkasm
+++ b/counters/tests/opSHA3.zkasm
@@ -10,7 +10,7 @@ operation:
             :JMP(opSHA3)
 checkCounters:
 3300 - STEP:JMPN(failedCounters)
-146 - CNT_BINARY :JMPNZ(failedCounters)
+145 - CNT_BINARY :JMPNZ(failedCounters)
 9 - CNT_ARITH :JMPNZ(failedCounters)
 15 - CNT_KECCAK_F :JMPNZ(failedCounters)
 63 - CNT_MEM_ALIGN :JMPNZ(failedCounters)

--- a/main/main.zkasm
+++ b/main/main.zkasm
@@ -23,7 +23,7 @@ start: ; main zkROM entry point
         ${getGlobalExitRoot()}              :MSTORE(globalExitRoot)
         ${getSequencerAddr()}               :MSTORE(sequencerAddr)
         ${getTimestamp()}                   :MSTORE(timestamp)
-        ${getTxsLen()}                      :MSTORE(batchL2DataLength)
+        ${getTxsLen()}                      :MSTORE(batchL2DataLength) ; less than 300.000 bytes. Enforced by the smart contract
 
         B => SR ;set initial state root
 
@@ -81,9 +81,8 @@ skipSetGlobalExitRoot:
         136                                     :MSTORE(arithB), CALL(divARITH); in: [arithA, arithB] out: [arithRes1: arithA/arithB, arithRes2: arithA%arithB]
         $ => B                                  :MLOAD(arithRes1)
         ; Compute minimum necessary keccaks to finish the batch
-        B + 1 + %MIN_CNT_KECCAK_BATCH           :MSTORE(cntKeccakPreProcess)
-        %MAX_CNT_KECCAK_F - CNT_KECCAK_F => A
-        $                                       :LT, JMPC(outOfCountersKeccak)
+        B + 1 + %MIN_CNT_KECCAK_BATCH => B      :MSTORE(cntKeccakPreProcess)
+        %MAX_CNT_KECCAK_F - CNT_KECCAK_F - B    :JMPN(handleOOCKatRLP)
 
 ;;;;;;;;;;;;;;;;;;
 ;; C - Loop parsing RLP transactions

--- a/main/opcodes/calldata-returndata-code.zkasm
+++ b/main/opcodes/calldata-returndata-code.zkasm
@@ -475,13 +475,12 @@ opEXTCODECOPYLoadBytecode:
 
     ; check poseidon counters
     ; 56 is the value used by the prover to increment poseidon counters depending on the hash length
-    RR              :MSTORE(tmpZkPCext)
-    B + 1           :MSTORE(arithA)
-    56              :MSTORE(arithB), CALL(divARITH); in: [arithA, arithB] out: [arithRes1: arithA/arithB, arithRes2: arithA%arithB]
-    $ => RR         :MLOAD(tmpZkPCext)
-    $ => B          :MLOAD(arithRes1)
-    %MAX_CNT_POSEIDON_G - CNT_POSEIDON_G - 255 - 1 => A
-    $               :LT, JMPC(outOfCountersPoseidon)
+    RR                                                  :MSTORE(tmpZkPCext)
+    B + 1                                               :MSTORE(arithA)
+    56                                                  :MSTORE(arithB), CALL(divARITH); in: [arithA, arithB] out: [arithRes1: arithA/arithB, arithRes2: arithA%arithB]
+    $ => RR                                             :MLOAD(tmpZkPCext)
+    $ => B                                              :MLOAD(arithRes1)
+    %MAX_CNT_POSEIDON_G - CNT_POSEIDON_G - 255 - 1 - B  :JMPN(outOfCountersPoseidon)
 
     ; set key for smt smart contract code query
     E => A

--- a/main/opcodes/crypto.zkasm
+++ b/main/opcodes/crypto.zkasm
@@ -45,8 +45,7 @@ opSHA3:
     $ => B          :MLOAD(arithRes1)
     $ => A          :MLOAD(cntKeccakPreProcess)
     ; checks keccak counters
-    %MAX_CNT_KECCAK_F - CNT_KECCAK_F - A - 1 => A
-    $               :LT, JMPC(outOfCountersKeccak)
+    %MAX_CNT_KECCAK_F - CNT_KECCAK_F - A - 1 - B :JMPN(outOfCountersKeccak)
 
     ; new hash id
     $ => B           :MLOAD(lastHashKIdUsed)

--- a/main/process-tx.zkasm
+++ b/main/process-tx.zkasm
@@ -238,15 +238,14 @@ nonceIs0:
 
 ;; compute new contract address as CREATE2 spec: keccak256(0xff ++ address ++ salt ++ keccak256(init_code))[12:] (https://eips.ethereum.org/EIPS/eip-1014)
 create2:
-        $ => C                          :MLOAD(txCalldataLen)
+        $ => C                          :MLOAD(txCalldataLen) ; less than 2**32 bytes. Enforced by memory expansion gas cost & smart contract batchL2DataHash
         ; Check keccak counters
         C + 1                           :MSTORE(arithA)
         136                             :MSTORE(arithB), CALL(divARITH); in: [arithA, arithB] out: [arithRes1: arithA/arithB, arithRes2: arithA%arithB]
         $ => B                          :MLOAD(arithRes1)
         $ => A                          :MLOAD(cntKeccakPreProcess)
         ; -2 because we will use one more keccack for generating contract address
-        %MAX_CNT_KECCAK_F - CNT_KECCAK_F - A - 2 => A
-        $                               :LT, JMPC(outOfCountersKeccak)
+        %MAX_CNT_KECCAK_F - CNT_KECCAK_F - A - 2 - B :JMPN(outOfCountersKeccak)
 
         $ => CTX                        :MLOAD(originCTX)
         $ => B                          :MLOAD(argsOffsetCall)
@@ -393,11 +392,10 @@ callContract:
 
         ; check poseidon counters
         ; 56 is the value used by the prover to increment poseidon counters depending on the hash length
-        B               :MSTORE(arithA)
-        56              :MSTORE(arithB), CALL(divARITH); in: [arithA, arithB] out: [arithRes1: arithA/arithB, arithRes2: arithA%arithB]
-        $ => B          :MLOAD(arithRes1)
-        %MAX_CNT_POSEIDON_G - CNT_POSEIDON_G - 1 => A
-        $               :LT, JMPC(outOfCountersPoseidon)
+        B                                               :MSTORE(arithA)
+        56                                              :MSTORE(arithB), CALL(divARITH); in: [arithA, arithB] out: [arithRes1: arithA/arithB, arithRes2: arithA%arithB]
+        $ => B                                          :MLOAD(arithRes1)
+        %MAX_CNT_POSEIDON_G - CNT_POSEIDON_G - 1 - B    :JMPN(outOfCountersPoseidon)
 
         ; get hash contract
         $ => A                          :MLOAD(txDestAddr)

--- a/main/utils.zkasm
+++ b/main/utils.zkasm
@@ -1190,11 +1190,10 @@ hashPoseidonLinearFromMemory:
     C                               :JMPZ(hashPoseidonReturn)
     ; check poseidon counters
     ; 56 is the value used by the prover to increment poseidon counters depending on the hash length
-    C               :MSTORE(arithA)
-    56              :MSTORE(arithB), CALL(divARITH); in: [arithA, arithB] out: [arithRes1: arithA/arithB, arithRes2: arithA%arithB]
-    $ => B          :MLOAD(arithRes1)
-    %MAX_CNT_POSEIDON_G - CNT_POSEIDON_G - 1 => A
-    $               :LT, JMPC(outOfCountersPoseidon)
+    C                                               :MSTORE(arithA)
+    56                                              :MSTORE(arithB), CALL(divARITH); in: [arithA, arithB] out: [arithRes1: arithA/arithB, arithRes2: arithA%arithB]
+    $ => B                                          :MLOAD(arithRes1)
+    %MAX_CNT_POSEIDON_G - CNT_POSEIDON_G - 1 - B    :JMPN(outOfCountersPoseidon)
 
     ; get a new hashPId
     $ => B                          :MLOAD(nextHashPId)


### PR DESCRIPTION
This PR does the following:
- remove `LT` binary state-machine with `JMPN` since values to check are <32 bits
- removes issue regarding negative values in binary state-machine