### PR TITLE
Feature/revert precompiled

### DIFF
--- a/main/opcodes/block.zkasm
+++ b/main/opcodes/block.zkasm
@@ -67,7 +67,7 @@ opCOINBASE:
     GAS-%GAS_QUICK_STEP => GAS    :JMPN(outOfGas)
 
     $ => A          :MLOAD(sequencerAddr)
-    A               :MSTORE(SP++); [address => E]
+    A               :MSTORE(SP++); [coinbase address => SP]
     ; check stack overflow
     %CALLDATA_OFFSET - SP       :JMPN(stackOverflow, readCode)
 
@@ -86,7 +86,7 @@ opTIMESTAMP:
     ; check out-of-gas
     GAS-%GAS_QUICK_STEP => GAS    :JMPN(outOfGas)
     $ => A          :MLOAD(timestamp)
-    A               :MSTORE(SP++); [timestamp => E]
+    A               :MSTORE(SP++); [timestamp => SP]
     ; check stack overflow
     %CALLDATA_OFFSET - SP       :JMPN(stackOverflow, readCode)
 
@@ -106,7 +106,7 @@ opNUMBER:
     GAS - %GAS_QUICK_STEP => GAS  :JMPN(outOfGas)
     ; Get current tx count
     $ => D          :MLOAD(txCount)
-    D + 1           :MSTORE(SP++); [blockNumber => E]
+    D + 1           :MSTORE(SP++); [blockNumber => SP]
     ; check stack overflow
     %CALLDATA_OFFSET - SP       :JMPN(stackOverflow, readCode)
 
@@ -126,7 +126,7 @@ opDIFFICULTY:
     GAS-%GAS_QUICK_STEP => GAS    :JMPN(outOfGas)
     ; No difficulty, always 0
     %BATCH_DIFFICULTY => A
-    A               :MSTORE(SP++); [difficulty => E]
+    A               :MSTORE(SP++); [difficulty => SP]
     ; check stack overflow
     %CALLDATA_OFFSET - SP       :JMPN(stackOverflow, readCode)
 
@@ -146,7 +146,7 @@ opGASLIMIT:
     GAS-%GAS_QUICK_STEP => GAS    :JMPN(outOfGas)
     ; constant tx gas limit
     %TX_GAS_LIMIT => A
-    A               :MSTORE(SP++); [gasLimit => E]
+    A               :MSTORE(SP++); [gasLimit => SP]
     ; check stack overflow
     %CALLDATA_OFFSET - SP       :JMPN(stackOverflow, readCode)
 
@@ -165,6 +165,6 @@ opCHAINID:
     ; check out-of-gas
     GAS-%GAS_QUICK_STEP => GAS    :JMPN(outOfGas)
     $ => A          :MLOAD(chainID)
-    A               :MSTORE(SP++); [chainId => E]
+    A               :MSTORE(SP++); [chainId => SP]
     ; check stack overflow
     %CALLDATA_OFFSET - SP       :JMPN(stackOverflow, readCode)

--- a/main/opcodes/calldata-returndata-code.zkasm
+++ b/main/opcodes/calldata-returndata-code.zkasm
@@ -476,6 +476,7 @@ opEXTCODECOPYLoadBytecode:
     $ => RR                                             :MLOAD(tmpZkPCext)
     $ => B                                              :MLOAD(arithRes1)
     %MAX_CNT_POSEIDON_G - CNT_POSEIDON_G - 255 - 1 - B  :JMPN(outOfCountersPoseidon)
+    %MAX_CNT_PADDING_PG_LIMIT - CNT_PADDING_PG - 1 - B  :JMPN(outOfCountersPadding)
 
     ; set key for smt smart contract code query
     E => A

--- a/main/precompiled/end.zkasm
+++ b/main/precompiled/end.zkasm
@@ -4,9 +4,3 @@ preEnd:
     $ => SP         :MLOAD(lastSP)
     $ => PC         :MLOAD(lastPC)
     1               :MSTORE(SP++), JMP(readCode)
-
-preEndFail:
-    $ => GAS        :MLOAD(gasCTX)
-    $ => SP         :MLOAD(lastSP)
-    $ => PC         :MLOAD(lastPC)
-    0               :MSTORE(SP++), JMP(readCode)

--- a/main/precompiled/revert-precompiled.zkasm
+++ b/main/precompiled/revert-precompiled.zkasm
@@ -1,0 +1,24 @@
+revertPrecompiled:
+    ; load initSR to revert all state changes
+    ; revert touched accounts
+    $ => SR         :MLOAD(initSR), CALL(revertTouched)
+    $${eventLog(onError, revert)}
+
+    ; check if it is the first context
+    $ => A          :MLOAD(originCTX), JMPZ(handleGas) ; first context
+    A => CTX        :MSTORE(currentCTX)
+
+    ; return gas not used to previous context
+    $ => B          :MLOAD(gasCTX)
+    GAS + B => GAS
+
+    ; restore SP and PC
+    $ => SP         :MLOAD(lastSP)
+    $ => PC         :MLOAD(lastPC)
+
+    ; write 0 in previous context stack
+    0               :MSTORE(SP++)
+
+    ; decrease depth
+    $ => A          :MLOAD(depth)
+    A - 1           :MSTORE(depth), JMP(readCode)

--- a/main/precompiled/revert-precompiled.zkasm
+++ b/main/precompiled/revert-precompiled.zkasm
@@ -1,4 +1,6 @@
 revertPrecompiled:
+    %MAX_CNT_STEPS - STEP - 100         :JMPN(outOfCountersStep)
+
     ; load initSR to revert all state changes
     ; revert touched accounts
     $ => SR         :MLOAD(initSR), CALL(revertTouched)

--- a/main/precompiled/selector.zkasm
+++ b/main/precompiled/selector.zkasm
@@ -1,4 +1,5 @@
 INCLUDE "pre-ecrecover.zkasm"
+INCLUDE "revert-precompiled.zkasm"
 INCLUDE "identity.zkasm"
 INCLUDE "end.zkasm"
 
@@ -6,14 +7,17 @@ INCLUDE "end.zkasm"
  * Selector precompiled contract to run
  * Current precompiled supported: ECRECOVER & IDENTITY
  * @param {A} - Precompiled address
+ * @dev Any call to an unsupported precompiled will result in a revert
+ *  - All gas is refunded
+ *  - 0 is returned
  */
 selectorPrecompiled:
     A - 2               :JMPN(funcECRECOVER)
-    A - 3               :JMPN(callContract)  ;:JMPN(SHA256)
-    A - 4               :JMPN(callContract)  ;:JMPN(RIPEMD160)
+    A - 3               :JMPN(revertPrecompiled)  ;:JMPN(SHA256)
+    A - 4               :JMPN(revertPrecompiled)  ;:JMPN(RIPEMD160)
     A - 5               :JMPN(IDENTITY)
-    A - 6               :JMPN(callContract) ;:JMPN(MODEXP)
-    A - 7               :JMPN(callContract) ;:JMPN(ECADD)
-    A - 8               :JMPN(callContract) ;:JMPN(ECMUL)
-    A - 9               :JMPN(callContract) ;:JMPN(ECPAIRING)
-    A - 10              :JMPN(callContract) ;:JMPN(BLAKE2F)
+    A - 6               :JMPN(revertPrecompiled) ;:JMPN(MODEXP)
+    A - 7               :JMPN(revertPrecompiled) ;:JMPN(ECADD)
+    A - 8               :JMPN(revertPrecompiled) ;:JMPN(ECMUL)
+    A - 9               :JMPN(revertPrecompiled) ;:JMPN(ECPAIRING)
+    A - 10              :JMPN(revertPrecompiled) ;:JMPN(BLAKE2F)

--- a/main/process-tx.zkasm
+++ b/main/process-tx.zkasm
@@ -392,10 +392,11 @@ callContract:
 
         ; check poseidon counters
         ; 56 is the value used by the prover to increment poseidon counters depending on the hash length
-        B                                               :MSTORE(arithA)
-        56                                              :MSTORE(arithB), CALL(divARITH); in: [arithA, arithB] out: [arithRes1: arithA/arithB, arithRes2: arithA%arithB]
-        $ => B                                          :MLOAD(arithRes1)
-        %MAX_CNT_POSEIDON_G - CNT_POSEIDON_G - 1 - B    :JMPN(outOfCountersPoseidon)
+        B                                                       :MSTORE(arithA)
+        56                                                      :MSTORE(arithB), CALL(divARITH); in: [arithA, arithB] out: [arithRes1: arithA/arithB, arithRes2: arithA%arithB]
+        $ => B                                                  :MLOAD(arithRes1)
+        %MAX_CNT_POSEIDON_G - CNT_POSEIDON_G - 1 - B            :JMPN(outOfCountersPoseidon)
+        %MAX_CNT_PADDING_PG_LIMIT - CNT_PADDING_PG - 1 - B      :JMPN(outOfCountersPadding)
 
         ; get hash contract
         $ => A                          :MLOAD(txDestAddr)

--- a/main/utils.zkasm
+++ b/main/utils.zkasm
@@ -438,8 +438,16 @@ computeGasSendCall:
 
     ; compute all_but_one_64th gas
     GAS => A
-    ${GAS >> 6} => C
+
+    ; C = [c7, c6, ..., c0]
+    ; JMPN instruction assures c0 is within the range [0, 2**32 - 1]
+    ${GAS >> 6} => C        :JMPN(failAssert)
     ${GAS & 0x3f} => D
+
+    ; since D is assured to be less than 0x40
+    ; it is enforced that [c7, c6, ..., c1] are 0 since there is no value multiplied by 64
+    ; that equals the field
+    ; Since e0 is assured to be less than 32 bits, c0 * 64 + d0 could not overflow the field
     C * 64 + D              :ASSERT
     D => A
     0x40 => B
@@ -501,8 +509,16 @@ saveMemGAS:
     ; memory_size_word = (memory_byte_size + 31) / 32 in E
     ; ${(B+31)/32} => E
     E + 31 => A
-    ${A >> 5} => E
+
+    ; E = [e7, e6, ..., e0]
+    ; JMPN instruction assures e0 is within the range [0, 2**32 - 1]
+    ${A >> 5} => E              :JMPN(failAssert)
     ${A & 0x1f} => D
+
+    ; since D is assured to be less than 0x20
+    ; it is enforced that [e7, e6, ..., e1] are 0 since there is no value multiplied by 32
+    ; that equals the field
+    ; Since e0 is assured to be less than 32 bits, e0 * 32 + d0 could not overflow the field
     E * 32 + D                  :ASSERT
     D => A
     0x20 => B
@@ -889,8 +905,15 @@ offsetUtil:
     A                                   :MSTORE(tmpVarAoffsetUtil)
     B                                   :MSTORE(tmpVarBoffsetUtil)
 
-    ${A >> 5} => E
+    ; E = [e7, e6, ..., e0]
+    ; JMPN instruction assures e0 is within the range [0, 2**32 - 1]
+    ${A >> 5} => E                      :JMPN(failAssert)
     ${A & 0x1F} => C
+
+    ; since C is assured to be less than 0x20
+    ; it is enforced that [e7, e6, ..., e1] are 0 since there is no value multiplied by 32
+    ; that equals the field
+    ; Since e0 is assured to be less than 32 bits, e0 * 32 + c0 could not overflow the field
     E * 32 + C                          :ASSERT
     C => A
     0x20 => B
@@ -981,10 +1004,18 @@ readPush:
     D => A
     0                           :MSTORE(accumulator)
     PC + D - 1 => HASHPOS
-    ${A >> 2} => B
+
+    ; B = [b7, b6, ..., b0]
+    ; JMPN instruction assures b0 is within the range [0, 2**32 - 1]
+    ${A >> 2} => B              :JMPN(failAssert)
     B                           :MSTORE(numBlocks)
     ${A & 0x03} => D
     D                           :MSTORE(leftBytes)
+
+    ; since D is assured to be less than 0x04
+    ; it is enforced that [b7, b6, ..., b1] are 0 since there is no value multiplied by 4
+    ; that equals the field
+    ; Since b0 is assured to be less than 32 bits, b0 * 4 + d0 could not overflow the field
     B * 4 + D                   :ASSERT
     D => A
     0x04 => B
@@ -1174,10 +1205,11 @@ hashPoseidonLinearFromMemory:
     C                               :JMPZ(hashPoseidonReturn)
     ; check poseidon counters
     ; 56 is the value used by the prover to increment poseidon counters depending on the hash length
-    C                                               :MSTORE(arithA)
-    56                                              :MSTORE(arithB), CALL(divARITH); in: [arithA, arithB] out: [arithRes1: arithA/arithB, arithRes2: arithA%arithB]
-    $ => B                                          :MLOAD(arithRes1)
-    %MAX_CNT_POSEIDON_G - CNT_POSEIDON_G - 1 - B    :JMPN(outOfCountersPoseidon)
+    C                                                       :MSTORE(arithA)
+    56                                                      :MSTORE(arithB), CALL(divARITH); in: [arithA, arithB] out: [arithRes1: arithA/arithB, arithRes2: arithA%arithB]
+    $ => B                                                  :MLOAD(arithRes1)
+    %MAX_CNT_POSEIDON_G - CNT_POSEIDON_G - 1 - B            :JMPN(outOfCountersPoseidon)
+    %MAX_CNT_PADDING_PG_LIMIT - CNT_PADDING_PG - 1 - B      :JMPN(outOfCountersPadding)
 
     ; get a new hashPId
     $ => B                          :MLOAD(nextHashPId)

--- a/main/utils.zkasm
+++ b/main/utils.zkasm
@@ -960,7 +960,10 @@ invalidCall:
     GAS + A => GAS
     $ => SP                         :MLOAD(lastSP)
     $ => PC                         :MLOAD(lastPC)
-    0                               :MSTORE(SP++), JMP(readCode)
+    0                               :MSTORE(SP++)
+    ; decrease depth
+    $ => A                          :MLOAD(depth)
+    A - 1                           :MSTORE(depth), JMP(readCode)
 
 VAR GLOBAL pushBytes
 VAR GLOBAL numBlocks

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     "yargs": "^17.5.1"
   },
   "devDependencies": {
-    "@0xpolygonhermez/zkevm-proverjs": "github:0xPolygonHermez/zkevm-proverjs#feature/fork-id",
-    "@0xpolygonhermez/zkevm-testvectors": "github:0xPolygonHermez/zkevm-testvectors#feature/fork-id",
+    "@0xpolygonhermez/zkevm-proverjs": "github:0xPolygonHermez/zkevm-proverjs#885fa92827282b8c977f55c9e1d4ffe8b16a6b53",
+    "@0xpolygonhermez/zkevm-testvectors": "github:0xPolygonHermez/zkevm-testvectors#06449c4e77374303e0c7206b584048b321e667e0",
     "chai": "^4.3.6",
     "chalk": "^3.0.0",
     "eslint": "^8.25.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@0xpolygonhermez/zkevm-proverjs": "github:0xPolygonHermez/zkevm-proverjs#develop",
-    "@0xpolygonhermez/zkevm-testvectors": "github:0xPolygonHermez/zkevm-testvectors#develop",
+    "@0xpolygonhermez/zkevm-testvectors": "github:0xPolygonHermez/zkevm-testvectors#feature/fork-id",
     "chai": "^4.3.6",
     "chalk": "^3.0.0",
     "eslint": "^8.25.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "yargs": "^17.5.1"
   },
   "devDependencies": {
-    "@0xpolygonhermez/zkevm-proverjs": "github:0xPolygonHermez/zkevm-proverjs#develop",
+    "@0xpolygonhermez/zkevm-proverjs": "github:0xPolygonHermez/zkevm-proverjs#feature/fork-id",
     "@0xpolygonhermez/zkevm-testvectors": "github:0xPolygonHermez/zkevm-testvectors#feature/fork-id",
     "chai": "^4.3.6",
     "chalk": "^3.0.0",


### PR DESCRIPTION
This PR does the following:
- revert when calling a precompiled that is not supported
- add zk-counter check `PADDING_PG_LIMIT`
- assure 32 bit range for certain free inputs