### PR TITLE
fixes identity and not set CTX to 0

### DIFF
--- a/main/end.zkasm
+++ b/main/end.zkasm
@@ -1,4 +1,4 @@
 finalWait:
     ${beforeLast()}                                       :JMPN(finalWait)
-    ; Set all registers to 0 except inputs: B (oldstateRoot), C (oldAccInputHash), SP (oldNumBatch) & GAS (chainID)
-    0 => A, D, E, CTX, PC, MAXMEM, SR, HASHPOS, RR, RCX   :JMP(start)
+    ; Set all registers to 0 except inputs: B (oldstateRoot), C (oldAccInputHash), SP (oldNumBatch), GAS (chainID) & CTX (forkID)
+    0 => A, D, E, PC, MAXMEM, SR, HASHPOS, RR, RCX   :JMP(start)

--- a/main/precompiled/identity.zkasm
+++ b/main/precompiled/identity.zkasm
@@ -18,8 +18,9 @@ IDENTITY:
     GAS - %IDENTITY_WORD_GAS*A => GAS   :JMPN(outOfGas)
     CTX             :MSTORE(currentCTX)
     CTX => A
-    $ => CTX        :MLOAD(originCTX), JMPZ(handleGas)
-    A               :MSTORE(retDataCTX)
+    $ => B               :MLOAD(originCTX), JMPZ(handleGas)
+    B => CTX
+    A                    :MSTORE(retDataCTX)
     A => CTX
     0 => B
     0 => E


### PR DESCRIPTION
This PR does the following:
- fixes `identity` precompiled which saves CTX prior to jump to  `handleGas` function
- fixes set `CTX` to 0 since it should be set at its initial value, `forkID`