### PR TITLE
Feature/fix rlp

### DIFF
--- a/counters/README.md
+++ b/counters/README.md
@@ -22,7 +22,7 @@ checkCounters:
 %OPADD_CNT_PADDING_PG - CNT_PADDING_PG :JMPNZ(failedCounters)
 %OPADD_CNT_POSEIDON_G - CNT_POSEIDON_G :JMPNZ(failedCounters)
 // Finalize execution
-0 => A,B,C,D,E,CTX, SP, PC, GAS, MAXMEM, SR, HASHPOS, RR ; Set all registers to 0
+0 => A,B,C,D,E,CTX, SP, PC, GAS,  SR, HASHPOS, RR ; Set all registers to 0
 finalizeExecution:
                                                                         :JMP(finalWait)
 readCode:

--- a/counters/tests/MLOAD32.zkasm
+++ b/counters/tests/MLOAD32.zkasm
@@ -15,7 +15,7 @@ operation:
     %MLOAD32_CNT_PADDING_PG - CNT_PADDING_PG :JMPNZ(failedCounters)
     %MLOAD32_CNT_POSEIDON_G - CNT_POSEIDON_G :JMPNZ(failedCounters)
 
-0 => A,B,C,D,E,CTX, SP, PC, GAS, MAXMEM, SR, HASHPOS, RR ; Set all registers to 0
+0 => A,B,C,D,E,CTX, SP, PC, GAS,  SR, HASHPOS, RR ; Set all registers to 0
 finalizeExecution:
                                                                         :JMP(finalWait)
 readCode:

--- a/counters/tests/MLOADX.zkasm
+++ b/counters/tests/MLOADX.zkasm
@@ -18,7 +18,7 @@ operation:
     %MLOADX_CNT_PADDING_PG - CNT_PADDING_PG :JMPNZ(failedCounters)
     %MLOADX_CNT_POSEIDON_G - CNT_POSEIDON_G :JMPNZ(failedCounters)
 
-0 => A,B,C,D,E,CTX, SP, PC, GAS, MAXMEM, SR, HASHPOS, RR ; Set all registers to 0
+0 => A,B,C,D,E,CTX, SP, PC, GAS,  SR, HASHPOS, RR ; Set all registers to 0
 finalizeExecution:
                                                                         :JMP(finalWait)
 readCode:

--- a/counters/tests/MSTORE32.zkasm
+++ b/counters/tests/MSTORE32.zkasm
@@ -20,7 +20,7 @@ operation:
     %MSTORE32_CNT_PADDING_PG - CNT_PADDING_PG :JMPNZ(failedCounters)
     %MSTORE32_CNT_POSEIDON_G - CNT_POSEIDON_G :JMPNZ(failedCounters)
 
-0 => A,B,C,D,E,CTX, SP, PC, GAS, MAXMEM, SR, HASHPOS, RR ; Set all registers to 0
+0 => A,B,C,D,E,CTX, SP, PC, GAS,  SR, HASHPOS, RR ; Set all registers to 0
 finalizeExecution:
                                                                         :JMP(finalWait)
 readCode:

--- a/counters/tests/MSTOREX.zkasm
+++ b/counters/tests/MSTOREX.zkasm
@@ -24,7 +24,7 @@ operation:
     %MSTOREX_CNT_PADDING_PG - CNT_PADDING_PG :JMPNZ(failedCounters)
     %MSTOREX_CNT_POSEIDON_G - CNT_POSEIDON_G :JMPNZ(failedCounters)
 
-0 => A,B,C,D,E,CTX, SP, PC, GAS, MAXMEM, SR, HASHPOS, RR ; Set all registers to 0
+0 => A,B,C,D,E,CTX, SP, PC, GAS,  SR, HASHPOS, RR ; Set all registers to 0
 finalizeExecution:
                                                                         :JMP(finalWait)
 readCode:

--- a/counters/tests/SHLarith.zkasm
+++ b/counters/tests/SHLarith.zkasm
@@ -16,7 +16,7 @@ operation:
     %SHLARITH_CNT_PADDING_PG - CNT_PADDING_PG :JMPNZ(failedCounters)
     %SHLARITH_CNT_POSEIDON_G - CNT_POSEIDON_G :JMPNZ(failedCounters)
 
-0 => A,B,C,D,E,CTX, SP, PC, GAS, MAXMEM, SR, HASHPOS, RR ; Set all registers to 0
+0 => A,B,C,D,E,CTX, SP, PC, GAS,  SR, HASHPOS, RR ; Set all registers to 0
 finalizeExecution:
                                                                         :JMP(finalWait)
 readCode:

--- a/counters/tests/SHLarithBit.zkasm
+++ b/counters/tests/SHLarithBit.zkasm
@@ -16,7 +16,7 @@ operation:
     %SHLARITHBIT_CNT_PADDING_PG - CNT_PADDING_PG :JMPNZ(failedCounters)
     %SHLARITHBIT_CNT_POSEIDON_G - CNT_POSEIDON_G :JMPNZ(failedCounters)
 
-0 => A,B,C,D,E,CTX, SP, PC, GAS, MAXMEM, SR, HASHPOS, RR ; Set all registers to 0
+0 => A,B,C,D,E,CTX, SP, PC, GAS,  SR, HASHPOS, RR ; Set all registers to 0
 finalizeExecution:
                                                                         :JMP(finalWait)
 readCode:

--- a/counters/tests/SHRarith.zkasm
+++ b/counters/tests/SHRarith.zkasm
@@ -16,7 +16,7 @@ operation:
     %SHRARITH_CNT_PADDING_PG - CNT_PADDING_PG :JMPNZ(failedCounters)
     %SHRARITH_CNT_POSEIDON_G - CNT_POSEIDON_G :JMPNZ(failedCounters)
 
-0 => A,B,C,D,E,CTX, SP, PC, GAS, MAXMEM, SR, HASHPOS, RR ; Set all registers to 0
+0 => A,B,C,D,E,CTX, SP, PC, GAS,  SR, HASHPOS, RR ; Set all registers to 0
 finalizeExecution:
                                                                         :JMP(finalWait)
 readCode:

--- a/counters/tests/SHRarithBit.zkasm
+++ b/counters/tests/SHRarithBit.zkasm
@@ -16,7 +16,7 @@ operation:
     %SHRARITHBIT_CNT_PADDING_PG - CNT_PADDING_PG :JMPNZ(failedCounters)
     %SHRARITHBIT_CNT_POSEIDON_G - CNT_POSEIDON_G :JMPNZ(failedCounters)
 
-0 => A,B,C,D,E,CTX, SP, PC, GAS, MAXMEM, SR, HASHPOS, RR ; Set all registers to 0
+0 => A,B,C,D,E,CTX, SP, PC, GAS,  SR, HASHPOS, RR ; Set all registers to 0
 finalizeExecution:
                                                                         :JMP(finalWait)
 readCode:

--- a/counters/tests/abs.zkasm
+++ b/counters/tests/abs.zkasm
@@ -18,7 +18,7 @@ operation:
     %ABS_CNT_PADDING_PG - CNT_PADDING_PG :JMPNZ(failedCounters)
     %ABS_CNT_POSEIDON_G - CNT_POSEIDON_G :JMPNZ(failedCounters)
 finalizeExecution:
-0 => A,B,C,D,E,CTX, SP, PC, GAS, MAXMEM, SR, HASHPOS, RR ; Set all registers to 0
+0 => A,B,C,D,E,CTX, SP, PC, GAS,  SR, HASHPOS, RR ; Set all registers to 0
                                                                         :JMP(finalWait)
 readCode:
     :RETURN

--- a/counters/tests/addBatchHashByteByByte.zkasm
+++ b/counters/tests/addBatchHashByteByByte.zkasm
@@ -19,7 +19,7 @@ operation:
     %ADDBATCHHASH_CNT_PADDING_PG - CNT_PADDING_PG :JMPNZ(failedCounters)
     %ADDBATCHHASH_CNT_POSEIDON_G - CNT_POSEIDON_G :JMPNZ(failedCounters)
 
-0 => A,B,C,D,E,CTX, SP, PC, GAS, MAXMEM, SR, HASHPOS, RR ; Set all registers to 0
+0 => A,B,C,D,E,CTX, SP, PC, GAS,  SR, HASHPOS, RR ; Set all registers to 0
 finalizeExecution:
                                                                         :JMP(finalWait)
 readCode:

--- a/counters/tests/computeGasSendCall.zkasm
+++ b/counters/tests/computeGasSendCall.zkasm
@@ -18,7 +18,7 @@ operation:
     %COMPUTEGASSENDCALL_CNT_PADDING_PG - CNT_PADDING_PG :JMPNZ(failedCounters)
     %COMPUTEGASSENDCALL_CNT_POSEIDON_G - CNT_POSEIDON_G :JMPNZ(failedCounters)
 
-0 => A,B,C,D,E,CTX, SP, PC, GAS, MAXMEM, SR, HASHPOS, RR ; Set all registers to 0
+0 => A,B,C,D,E,CTX, SP, PC, GAS,  SR, HASHPOS, RR ; Set all registers to 0
 finalizeExecution:
                                                                         :JMP(finalWait)
 readCode:

--- a/counters/tests/copySP.zkasm
+++ b/counters/tests/copySP.zkasm
@@ -26,7 +26,7 @@ operation:
     %COPYSP_CNT_PADDING_PG + %MLOAD32_CNT_PADDING_PG*C - CNT_PADDING_PG :JMPNZ(failedCounters)
     %COPYSP_CNT_POSEIDON_G + %MLOAD32_CNT_POSEIDON_G*C - CNT_POSEIDON_G :JMPNZ(failedCounters)
 
-0 => A,B,C,D,E,CTX, SP, PC, GAS, MAXMEM, SR, HASHPOS, RR ; Set all registers to 0
+0 => A,B,C,D,E,CTX, SP, PC, GAS,  SR, HASHPOS, RR ; Set all registers to 0
 finalizeExecution:
                                                                         :JMP(finalWait)
 readCode:

--- a/counters/tests/divArith.zkasm
+++ b/counters/tests/divArith.zkasm
@@ -16,7 +16,7 @@ operation:
     %DIVARITH_CNT_PADDING_PG - CNT_PADDING_PG :JMPNZ(failedCounters)
     %DIVARITH_CNT_POSEIDON_G - CNT_POSEIDON_G :JMPNZ(failedCounters)
 finalizeExecution:
-0 => A,B,C,D,E,CTX, SP, PC, GAS, MAXMEM, SR, HASHPOS, RR ; Set all registers to 0
+0 => A,B,C,D,E,CTX, SP, PC, GAS,  SR, HASHPOS, RR ; Set all registers to 0
                                                                         :JMP(finalWait)
 readCode:
     :RETURN

--- a/counters/tests/expAD.zkasm
+++ b/counters/tests/expAD.zkasm
@@ -18,7 +18,7 @@ operation:
     %EXPAD_CNT_PADDING_PG - CNT_PADDING_PG :JMPNZ(failedCounters)
     %EXPAD_CNT_POSEIDON_G - CNT_POSEIDON_G :JMPNZ(failedCounters)
 
-0 => A,B,C,D,E,CTX, SP, PC, GAS, MAXMEM, SR, HASHPOS, RR ; Set all registers to 0
+0 => A,B,C,D,E,CTX, SP, PC, GAS,  SR, HASHPOS, RR ; Set all registers to 0
 finalizeExecution:
                                                                         :JMP(finalWait)
 readCode:

--- a/counters/tests/getLenBits.zkasm
+++ b/counters/tests/getLenBits.zkasm
@@ -18,7 +18,7 @@ operation:
 %GETLENBITS_CNT_PADDING_PG + %DIVARITH_CNT_PADDING_PG*C - CNT_PADDING_PG :JMPNZ(failedCounters)
 %GETLENBITS_CNT_POSEIDON_G + %DIVARITH_CNT_POSEIDON_G*C - CNT_POSEIDON_G :JMPNZ(failedCounters)
 
-0 => A,B,C,D,E,CTX, SP, PC, GAS, MAXMEM, SR, HASHPOS, RR ; Set all registers to 0
+0 => A,B,C,D,E,CTX, SP, PC, GAS,  SR, HASHPOS, RR ; Set all registers to 0
 finalizeExecution:
                                                                         :JMP(finalWait)
 readCode:

--- a/counters/tests/getLenBytes.zkasm
+++ b/counters/tests/getLenBytes.zkasm
@@ -20,7 +20,7 @@ operation:
 %GETLENBYTES_CNT_PADDING_PG + %SHRARITH_CNT_PADDING_PG*C - CNT_PADDING_PG :JMPNZ(failedCounters)
 %GETLENBYTES_CNT_POSEIDON_G + %SHRARITH_CNT_POSEIDON_G*C - CNT_POSEIDON_G :JMPNZ(failedCounters)
 
-0 => A,B,C,D,E,CTX, SP, PC, GAS, MAXMEM, SR, HASHPOS, RR ; Set all registers to 0
+0 => A,B,C,D,E,CTX, SP, PC, GAS,  SR, HASHPOS, RR ; Set all registers to 0
 finalizeExecution:
                                                                         :JMP(finalWait)
 readCode:

--- a/counters/tests/isEmptyAccount.zkasm
+++ b/counters/tests/isEmptyAccount.zkasm
@@ -18,7 +18,7 @@ operation:
     %ISEMPTYACCOUNT_CNT_PADDING_PG - CNT_PADDING_PG :JMPNZ(failedCounters)
     %ISEMPTYACCOUNT_CNT_POSEIDON_G - CNT_POSEIDON_G :JMPNZ(failedCounters)
 
-0 => A,B,C,D,E,CTX, SP, PC, GAS, MAXMEM, SR, HASHPOS, RR ; Set all registers to 0
+0 => A,B,C,D,E,CTX, SP, PC, GAS,  SR, HASHPOS, RR ; Set all registers to 0
 finalizeExecution:
                                                                         :JMP(finalWait)
 readCode:

--- a/counters/tests/mulARITH.zkasm
+++ b/counters/tests/mulARITH.zkasm
@@ -17,7 +17,7 @@ operation:
     %MULARITH_CNT_POSEIDON_G - CNT_POSEIDON_G :JMPNZ(failedCounters)
 
 finalizeExecution:
-0 => A,B,C,D,E,CTX, SP, PC, GAS, MAXMEM, SR, HASHPOS, RR ; Set all registers to 0
+0 => A,B,C,D,E,CTX, SP, PC, GAS,  SR, HASHPOS, RR ; Set all registers to 0
                                                                         :JMP(finalWait)
 readCode:
     :RETURN

--- a/counters/tests/offsetUtil.zkasm
+++ b/counters/tests/offsetUtil.zkasm
@@ -18,7 +18,7 @@ operation:
     %OFFSETUTIL_CNT_PADDING_PG - CNT_PADDING_PG :JMPNZ(failedCounters)
     %OFFSETUTIL_CNT_POSEIDON_G - CNT_POSEIDON_G :JMPNZ(failedCounters)
 finalizeExecution:
-0 => A,B,C,D,E,CTX, SP, PC, GAS, MAXMEM, SR, HASHPOS, RR ; Set all registers to 0
+0 => A,B,C,D,E,CTX, SP, PC, GAS,  SR, HASHPOS, RR ; Set all registers to 0
                                                                         :JMP(finalWait)
 readCode:
     :RETURN

--- a/counters/tests/opADDMOD.zkasm
+++ b/counters/tests/opADDMOD.zkasm
@@ -17,7 +17,7 @@ checkCounters:
 %OPADDMOD_CNT_PADDING_PG - CNT_PADDING_PG :JMPNZ(failedCounters)
 %OPADDMOD_CNT_POSEIDON_G - CNT_POSEIDON_G :JMPNZ(failedCounters)
 
-0 => A,B,C,D,E,CTX, SP, PC, GAS, MAXMEM, SR, HASHPOS, RR ; Set all registers to 0
+0 => A,B,C,D,E,CTX, SP, PC, GAS,  SR, HASHPOS, RR ; Set all registers to 0
 finalizeExecution:
                                                                         :JMP(finalWait)
 readCode:

--- a/counters/tests/opAdd.zkasm
+++ b/counters/tests/opAdd.zkasm
@@ -16,7 +16,7 @@ checkCounters:
 %OPADD_CNT_PADDING_PG - CNT_PADDING_PG :JMPNZ(failedCounters)
 %OPADD_CNT_POSEIDON_G - CNT_POSEIDON_G :JMPNZ(failedCounters)
 
-0 => A,B,C,D,E,CTX, SP, PC, GAS, MAXMEM, SR, HASHPOS, RR ; Set all registers to 0
+0 => A,B,C,D,E,CTX, SP, PC, GAS,  SR, HASHPOS, RR ; Set all registers to 0
 finalizeExecution:
                                                                         :JMP(finalWait)
 readCode:

--- a/counters/tests/opBLOCKHASH.zkasm
+++ b/counters/tests/opBLOCKHASH.zkasm
@@ -17,7 +17,7 @@ checkCounters:
 %OPBLOCKHASH_CNT_PADDING_PG - CNT_PADDING_PG :JMPNZ(failedCounters)
 %OPBLOCKHASH_CNT_POSEIDON_G - CNT_POSEIDON_G :JMPNZ(failedCounters)
 
-0 => A,B,C,D,E,CTX, SP, PC, GAS, MAXMEM, SR, HASHPOS, RR ; Set all registers to 0
+0 => A,B,C,D,E,CTX, SP, PC, GAS,  SR, HASHPOS, RR ; Set all registers to 0
 finalizeExecution:
                                                                         :JMP(finalWait)
 readCode:

--- a/counters/tests/opCALL.zkasm
+++ b/counters/tests/opCALL.zkasm
@@ -29,7 +29,7 @@ checkCounters:
 %OPCALL_CNT_PADDING_PG - CNT_PADDING_PG :JMPNZ(failedCounters)
 %OPCALL_CNT_POSEIDON_G - CNT_POSEIDON_G :JMPNZ(failedCounters)
 
-0 => A,B,C,D,E,CTX, SP, PC, GAS, MAXMEM, SR, HASHPOS, RR ; Set all registers to 0
+0 => A,B,C,D,E,CTX, SP, PC, GAS,  SR, HASHPOS, RR ; Set all registers to 0
 finalizeExecution:
                                                                         :JMP(finalWait)
 readCode:

--- a/counters/tests/opCALLCODE.zkasm
+++ b/counters/tests/opCALLCODE.zkasm
@@ -29,7 +29,7 @@ checkCounters:
 %OPCALLCODE_CNT_PADDING_PG - CNT_PADDING_PG :JMPNZ(failedCounters)
 %OPCALLCODE_CNT_POSEIDON_G - CNT_POSEIDON_G :JMPNZ(failedCounters)
 
-0 => A,B,C,D,E,CTX, SP, PC, GAS, MAXMEM, SR, HASHPOS, RR ; Set all registers to 0
+0 => A,B,C,D,E,CTX, SP, PC, GAS,  SR, HASHPOS, RR ; Set all registers to 0
 finalizeExecution:
                                                                         :JMP(finalWait)
 readCode:

--- a/counters/tests/opCALLDATACOPY.zkasm
+++ b/counters/tests/opCALLDATACOPY.zkasm
@@ -17,7 +17,7 @@ checkCounters:
 %OPCALLDATACOPY_CNT_PADDING_PG - CNT_PADDING_PG :JMPNZ(failedCounters)
 %OPCALLDATACOPY_CNT_POSEIDON_G - CNT_POSEIDON_G :JMPNZ(failedCounters)
 
-0 => A,B,C,D,E,CTX, SP, PC, GAS, MAXMEM, SR, HASHPOS, RR ; Set all registers to 0
+0 => A,B,C,D,E,CTX, SP, PC, GAS,  SR, HASHPOS, RR ; Set all registers to 0
 finalizeExecution:
                                                                         :JMP(finalWait)
 readCode:

--- a/counters/tests/opCALLDATALOAD.zkasm
+++ b/counters/tests/opCALLDATALOAD.zkasm
@@ -16,7 +16,7 @@ checkCounters:
 %OPCALLDATALOAD_CNT_PADDING_PG - CNT_PADDING_PG :JMPNZ(failedCounters)
 %OPCALLDATALOAD_CNT_POSEIDON_G - CNT_POSEIDON_G :JMPNZ(failedCounters)
 
-0 => A,B,C,D,E,CTX, SP, PC, GAS, MAXMEM, SR, HASHPOS, RR ; Set all registers to 0
+0 => A,B,C,D,E,CTX, SP, PC, GAS,  SR, HASHPOS, RR ; Set all registers to 0
 finalizeExecution:
                                                                         :JMP(finalWait)
 readCode:

--- a/counters/tests/opCODECOPY.zkasm
+++ b/counters/tests/opCODECOPY.zkasm
@@ -17,7 +17,7 @@ checkCounters:
 %OPCODECOPY_CNT_PADDING_PG - CNT_PADDING_PG :JMPNZ(failedCounters)
 %OPCODECOPY_CNT_POSEIDON_G - CNT_POSEIDON_G :JMPNZ(failedCounters)
 
-0 => A,B,C,D,E,CTX, SP, PC, GAS, MAXMEM, SR, HASHPOS, RR ; Set all registers to 0
+0 => A,B,C,D,E,CTX, SP, PC, GAS,  SR, HASHPOS, RR ; Set all registers to 0
 finalizeExecution:
                                                                         :JMP(finalWait)
 readCode:

--- a/counters/tests/opCREATE.zkasm
+++ b/counters/tests/opCREATE.zkasm
@@ -23,7 +23,7 @@ checkCounters:
 %OPCREATE_CNT_PADDING_PG - CNT_PADDING_PG :JMPNZ(failedCounters)
 %OPCREATE_CNT_POSEIDON_G - CNT_POSEIDON_G :JMPNZ(failedCounters)
 
-0 => A,B,C,D,E,CTX, SP, PC, GAS, MAXMEM, SR, HASHPOS, RR ; Set all registers to 0
+0 => A,B,C,D,E,CTX, SP, PC, GAS,  SR, HASHPOS, RR ; Set all registers to 0
 finalizeExecution:
                                                                         :JMP(finalWait)
 readCode:

--- a/counters/tests/opCREATE2.zkasm
+++ b/counters/tests/opCREATE2.zkasm
@@ -23,7 +23,7 @@ checkCounters:
 %OPCREATE2_CNT_PADDING_PG - CNT_PADDING_PG :JMPNZ(failedCounters)
 %OPCREATE2_CNT_POSEIDON_G - CNT_POSEIDON_G :JMPNZ(failedCounters)
 
-0 => A,B,C,D,E,CTX, SP, PC, GAS, MAXMEM, SR, HASHPOS, RR ; Set all registers to 0
+0 => A,B,C,D,E,CTX, SP, PC, GAS,  SR, HASHPOS, RR ; Set all registers to 0
 finalizeExecution:
                                                                         :JMP(finalWait)
 readCode:

--- a/counters/tests/opDELEGATECALL.zkasm
+++ b/counters/tests/opDELEGATECALL.zkasm
@@ -23,7 +23,7 @@ checkCounters:
 %OPDELEGATECALL_CNT_PADDING_PG - CNT_PADDING_PG :JMPNZ(failedCounters)
 %OPDELEGATECALL_CNT_POSEIDON_G - CNT_POSEIDON_G :JMPNZ(failedCounters)
 
-0 => A,B,C,D,E,CTX, SP, PC, GAS, MAXMEM, SR, HASHPOS, RR ; Set all registers to 0
+0 => A,B,C,D,E,CTX, SP, PC, GAS,  SR, HASHPOS, RR ; Set all registers to 0
 finalizeExecution:
                                                                         :JMP(finalWait)
 readCode:

--- a/counters/tests/opDIV.zkasm
+++ b/counters/tests/opDIV.zkasm
@@ -16,7 +16,7 @@ checkCounters:
 %OPDIV_CNT_PADDING_PG - CNT_PADDING_PG :JMPNZ(failedCounters)
 %OPDIV_CNT_POSEIDON_G - CNT_POSEIDON_G :JMPNZ(failedCounters)
 
-0 => A,B,C,D,E,CTX, SP, PC, GAS, MAXMEM, SR, HASHPOS, RR ; Set all registers to 0
+0 => A,B,C,D,E,CTX, SP, PC, GAS,  SR, HASHPOS, RR ; Set all registers to 0
 finalizeExecution:
                                                                         :JMP(finalWait)
 readCode:

--- a/counters/tests/opEXP.zkasm
+++ b/counters/tests/opEXP.zkasm
@@ -18,7 +18,7 @@ checkCounters:
 %OPEXP_CNT_PADDING_PG - CNT_PADDING_PG :JMPNZ(failedCounters)
 %OPEXP_CNT_POSEIDON_G - CNT_POSEIDON_G :JMPNZ(failedCounters)
 
-0 => A,B,C,D,E,CTX, SP, PC, GAS, MAXMEM, SR, HASHPOS, RR ; Set all registers to 0
+0 => A,B,C,D,E,CTX, SP, PC, GAS,  SR, HASHPOS, RR ; Set all registers to 0
 finalizeExecution:
                                                                         :JMP(finalWait)
 readCode:

--- a/counters/tests/opEXTCODECOPY.zkasm
+++ b/counters/tests/opEXTCODECOPY.zkasm
@@ -18,7 +18,7 @@ checkCounters:
 %OPEXTCODECOPY_CNT_PADDING_PG - CNT_PADDING_PG :JMPNZ(failedCounters)
 %OPEXTCODECOPY_CNT_POSEIDON_G - CNT_POSEIDON_G :JMPNZ(failedCounters)
 
-0 => A,B,C,D,E,CTX, SP, PC, GAS, MAXMEM, SR, HASHPOS, RR ; Set all registers to 0
+0 => A,B,C,D,E,CTX, SP, PC, GAS,  SR, HASHPOS, RR ; Set all registers to 0
 finalizeExecution:
                                                                         :JMP(finalWait)
 readCode:

--- a/counters/tests/opMOD.zkasm
+++ b/counters/tests/opMOD.zkasm
@@ -16,7 +16,7 @@ checkCounters:
 %OPMOD_CNT_PADDING_PG - CNT_PADDING_PG :JMPNZ(failedCounters)
 %OPMOD_CNT_POSEIDON_G - CNT_POSEIDON_G :JMPNZ(failedCounters)
 
-0 => A,B,C,D,E,CTX, SP, PC, GAS, MAXMEM, SR, HASHPOS, RR ; Set all registers to 0
+0 => A,B,C,D,E,CTX, SP, PC, GAS,  SR, HASHPOS, RR ; Set all registers to 0
 finalizeExecution:
                                                                         :JMP(finalWait)
 readCode:

--- a/counters/tests/opMUL.zkasm
+++ b/counters/tests/opMUL.zkasm
@@ -16,7 +16,7 @@ checkCounters:
 %OPMUL_CNT_PADDING_PG - CNT_PADDING_PG :JMPNZ(failedCounters)
 %OPMUL_CNT_POSEIDON_G - CNT_POSEIDON_G :JMPNZ(failedCounters)
 
-0 => A,B,C,D,E,CTX, SP, PC, GAS, MAXMEM, SR, HASHPOS, RR ; Set all registers to 0
+0 => A,B,C,D,E,CTX, SP, PC, GAS,  SR, HASHPOS, RR ; Set all registers to 0
 finalizeExecution:
                                                                         :JMP(finalWait)
 readCode:

--- a/counters/tests/opMULMOD.zkasm
+++ b/counters/tests/opMULMOD.zkasm
@@ -17,7 +17,7 @@ checkCounters:
 %OPMULMOD_CNT_PADDING_PG - CNT_PADDING_PG :JMPNZ(failedCounters)
 %OPMULMOD_CNT_POSEIDON_G - CNT_POSEIDON_G :JMPNZ(failedCounters)
 
-0 => A,B,C,D,E,CTX, SP, PC, GAS, MAXMEM, SR, HASHPOS, RR ; Set all registers to 0
+0 => A,B,C,D,E,CTX, SP, PC, GAS,  SR, HASHPOS, RR ; Set all registers to 0
 finalizeExecution:
                                                                         :JMP(finalWait)
 readCode:

--- a/counters/tests/opRETURN.zkasm
+++ b/counters/tests/opRETURN.zkasm
@@ -20,7 +20,7 @@ checkCounters:
 %OPRETURN_CNT_PADDING_PG - CNT_PADDING_PG :JMPNZ(failedCounters)
 %OPRETURN_CNT_POSEIDON_G - CNT_POSEIDON_G :JMPNZ(failedCounters)
 
-0 => A,B,C,D,E,CTX, SP, PC, GAS, MAXMEM, SR, HASHPOS, RR ; Set all registers to 0
+0 => A,B,C,D,E,CTX, SP, PC, GAS,  SR, HASHPOS, RR ; Set all registers to 0
 finalizeExecution:
                                                                         :JMP(finalWait)
 readCode:

--- a/counters/tests/opRETURNDATACOPY.zkasm
+++ b/counters/tests/opRETURNDATACOPY.zkasm
@@ -18,7 +18,7 @@ checkCounters:
 1000 - STEP:JMPN(failedCounters)
 
 
-0 => A,B,C,D,E,CTX, SP, PC, GAS, MAXMEM, SR, HASHPOS, RR ; Set all registers to 0
+0 => A,B,C,D,E,CTX, SP, PC, GAS,  SR, HASHPOS, RR ; Set all registers to 0
 finalizeExecution:
                                                                         :JMP(finalWait)
 readCode:

--- a/counters/tests/opREVERT.zkasm
+++ b/counters/tests/opREVERT.zkasm
@@ -20,7 +20,7 @@ checkCounters:
 %OPREVERT_CNT_PADDING_PG - CNT_PADDING_PG :JMPNZ(failedCounters)
 %OPREVERT_CNT_POSEIDON_G - CNT_POSEIDON_G :JMPNZ(failedCounters)
 
-0 => A,B,C,D,E,CTX, SP, PC, GAS, MAXMEM, SR, HASHPOS, RR ; Set all registers to 0
+0 => A,B,C,D,E,CTX, SP, PC, GAS,  SR, HASHPOS, RR ; Set all registers to 0
 finalizeExecution:
                                                                         :JMP(finalWait)
 readCode:

--- a/counters/tests/opSDIV.zkasm
+++ b/counters/tests/opSDIV.zkasm
@@ -17,7 +17,7 @@ checkCounters:
 %OPSDIV_CNT_PADDING_PG - CNT_PADDING_PG :JMPNZ(failedCounters)
 %OPSDIV_CNT_POSEIDON_G - CNT_POSEIDON_G :JMPNZ(failedCounters)
 
-0 => A,B,C,D,E,CTX, SP, PC, GAS, MAXMEM, SR, HASHPOS, RR ; Set all registers to 0
+0 => A,B,C,D,E,CTX, SP, PC, GAS,  SR, HASHPOS, RR ; Set all registers to 0
 finalizeExecution:
                                                                         :JMP(finalWait)
 readCode:

--- a/counters/tests/opSHA3.zkasm
+++ b/counters/tests/opSHA3.zkasm
@@ -17,7 +17,7 @@ checkCounters:
 %OPSHA3_CNT_PADDING_PG - CNT_PADDING_PG :JMPNZ(failedCounters)
 %OPSHA3_CNT_POSEIDON_G - CNT_POSEIDON_G :JMPNZ(failedCounters)
 
-0 => A,B,C,D,E,CTX, SP, PC, GAS, MAXMEM, SR, HASHPOS, RR ; Set all registers to 0
+0 => A,B,C,D,E,CTX, SP, PC, GAS,  SR, HASHPOS, RR ; Set all registers to 0
 finalizeExecution:
                                                                         :JMP(finalWait)
 readCode:

--- a/counters/tests/opSIGNEXTEND.zkasm
+++ b/counters/tests/opSIGNEXTEND.zkasm
@@ -16,7 +16,7 @@ checkCounters:
 %OPSIGNEXTEND_CNT_PADDING_PG - CNT_PADDING_PG :JMPNZ(failedCounters)
 %OPSIGNEXTEND_CNT_POSEIDON_G - CNT_POSEIDON_G :JMPNZ(failedCounters)
 
-0 => A,B,C,D,E,CTX, SP, PC, GAS, MAXMEM, SR, HASHPOS, RR ; Set all registers to 0
+0 => A,B,C,D,E,CTX, SP, PC, GAS,  SR, HASHPOS, RR ; Set all registers to 0
 finalizeExecution:
                                                                         :JMP(finalWait)
 readCode:

--- a/counters/tests/opSMOD.zkasm
+++ b/counters/tests/opSMOD.zkasm
@@ -17,7 +17,7 @@ checkCounters:
 %OPSMOD_CNT_PADDING_PG - CNT_PADDING_PG :JMPNZ(failedCounters)
 %OPSMOD_CNT_POSEIDON_G - CNT_POSEIDON_G :JMPNZ(failedCounters)
 
-0 => A,B,C,D,E,CTX, SP, PC, GAS, MAXMEM, SR, HASHPOS, RR ; Set all registers to 0
+0 => A,B,C,D,E,CTX, SP, PC, GAS,  SR, HASHPOS, RR ; Set all registers to 0
 finalizeExecution:
                                                                         :JMP(finalWait)
 readCode:

--- a/counters/tests/opSTATICCALL.zkasm
+++ b/counters/tests/opSTATICCALL.zkasm
@@ -23,7 +23,7 @@ checkCounters:
 %OPSTATICCALL_CNT_PADDING_PG - CNT_PADDING_PG :JMPNZ(failedCounters)
 %OPSTATICCALL_CNT_POSEIDON_G - CNT_POSEIDON_G :JMPNZ(failedCounters)
 
-0 => A,B,C,D,E,CTX, SP, PC, GAS, MAXMEM, SR, HASHPOS, RR ; Set all registers to 0
+0 => A,B,C,D,E,CTX, SP, PC, GAS,  SR, HASHPOS, RR ; Set all registers to 0
 finalizeExecution:
                                                                         :JMP(finalWait)
 readCode:

--- a/counters/tests/opSUB.zkasm
+++ b/counters/tests/opSUB.zkasm
@@ -16,7 +16,7 @@ checkCounters:
 %OPSUB_CNT_PADDING_PG - CNT_PADDING_PG :JMPNZ(failedCounters)
 %OPSUB_CNT_POSEIDON_G - CNT_POSEIDON_G :JMPNZ(failedCounters)
 
-0 => A,B,C,D,E,CTX, SP, PC, GAS, MAXMEM, SR, HASHPOS, RR ; Set all registers to 0
+0 => A,B,C,D,E,CTX, SP, PC, GAS,  SR, HASHPOS, RR ; Set all registers to 0
 finalizeExecution:
                                                                         :JMP(finalWait)
 readCode:

--- a/counters/tests/saveMem.zkasm
+++ b/counters/tests/saveMem.zkasm
@@ -19,7 +19,7 @@ operation:
     %SAVEMEM_CNT_PADDING_PG - CNT_PADDING_PG :JMPNZ(failedCounters)
     %SAVEMEM_CNT_POSEIDON_G - CNT_POSEIDON_G :JMPNZ(failedCounters)
 
-0 => A,B,C,D,E,CTX, SP, PC, GAS, MAXMEM, SR, HASHPOS, RR ; Set all registers to 0
+0 => A,B,C,D,E,CTX, SP, PC, GAS,  SR, HASHPOS, RR ; Set all registers to 0
 finalizeExecution:
                                                                         :JMP(finalWait)
 readCode:

--- a/main/end.zkasm
+++ b/main/end.zkasm
@@ -1,4 +1,4 @@
 finalWait:
     ${beforeLast()}                                       :JMPN(finalWait)
     ; Set all registers to 0 except inputs: B (oldstateRoot), C (oldAccInputHash), SP (oldNumBatch), GAS (chainID) & CTX (forkID)
-    0 => A, D, E, PC, MAXMEM, SR, HASHPOS, RR, RCX   :JMP(start)
+    0 => A, D, E, PC, SR, HASHPOS, RR, RCX   :JMP(start)

--- a/main/load-tx-rlp.zkasm
+++ b/main/load-tx-rlp.zkasm
@@ -37,8 +37,8 @@ loadTx_rlp:
 
 longList:
         A - 0xf7 => D                   :CALL(addHashTx)
-                                        :CALL(checkLongRLP)
                                         :CALL(addBatchHashData)
+                                        :CALL(checkLongRLP)
                                         :JMP(endList)
 shortList:
         A - 0xc0 => A
@@ -67,8 +67,8 @@ nonce0:
 shortNonce:
         A - 0x80 => D
         D                               :MSTORE(lengthNonce), CALL(addHashTx)
-                                        :CALL(checkShortRLP)
                                         :CALL(addBatchHashData)
+                                        :CALL(checkShortRLP)
 
 endNonce:
         A                               :MSTORE(txNonce)
@@ -88,8 +88,8 @@ gasPrice0:
 
 shortGasPrice:
         A - 0x80 => D                   :CALL(addHashTx)
-                                        :CALL(checkShortRLP)
                                         :CALL(addBatchHashData)
+                                        :CALL(checkShortRLP)
 
 endGasPrice:
         A                               :MSTORE(txGasPriceRLP)
@@ -109,8 +109,8 @@ gasLimit0:
 
 shortGasLimit:
         A - 0x80 => D                   :CALL(addHashTx)
-                                        :CALL(checkShortRLP)
                                         :CALL(addBatchHashData)
+                                        :CALL(checkShortRLP)
 
 endGasLimit:
         A                               :MSTORE(txGasLimit)
@@ -150,8 +150,8 @@ value0:
 
 shortValue:
         A - 0x80 => D                   :CALL(addHashTx)
-                                        :CALL(checkShortRLP)
                                         :CALL(addBatchHashData)
+                                        :CALL(checkShortRLP)
 
 endValue:
         A                               :MSTORE(txValue)
@@ -181,8 +181,8 @@ shortData:
 
 longData:
         A - 0xb7 => D                   :CALL(addHashTx)
-                                        :CALL(checkLongRLP)
                                         :CALL(addBatchHashData)
+                                        :CALL(checkLongRLP)
         $ => D                          :MLOAD(batchHashPos)
         D                               :MSTORE(dataStarts)
         A => B                          :MSTORE(txCalldataLen)
@@ -197,10 +197,10 @@ readData:
 readDataFinal:
         B - 1                           :JMPN(endData)
         B => D                          :CALL(addHashTx)
-                                        :CALL(checkShortDataRLP)
         32 - D => D                     :CALL(SHLarith)
         A                               :MSTORE(SP)
         32 - D => D                     :CALL(addBatchHashByteByByte)
+                                        :CALL(checkShortDataRLP)
 
 endData:
         ; Check all bytes read to detect pre EIP-155 tx
@@ -223,8 +223,8 @@ chainId0:
 
 shortChainId:
         A - 0x80 => D                   :CALL(addHashTx)
-                                        :CALL(checkShortRLP)
                                         :CALL(addBatchHashData)
+                                        :CALL(checkShortRLP)
 
 endChainId:
         A                               :MSTORE(txChainId)

--- a/main/opcodes/storage-memory.zkasm
+++ b/main/opcodes/storage-memory.zkasm
@@ -160,8 +160,8 @@ opSLOAD:
     $ => A          :MLOAD(storageAddr)
     ; set key for smt storage query
     %SMT_KEY_SC_STORAGE => B
-    $${eventLog(onUpdateStorage)}
     $ => E          :SLOAD
+    $${eventLog(onUpdateStorage(C, E))}
     ; set key(C) as warmed storage for address(A)
     E               :MSTORE(SP++), CALL(isColdSlot); [value(E) => SP]
     ; check out-of-gas
@@ -306,5 +306,5 @@ opSSTOREsr:
     ; set key for smt storage query
     %SMT_KEY_SC_STORAGE => B
     $ => C          :MLOAD(tmpVarCsstore); key => C
-    $${eventLog(onUpdateStorage)}
+    $${eventLog(onUpdateStorage(C, D))}
     $ => SR         :SSTORE, JMP(readCode)

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@0xpolygonhermez/zkevm-proverjs": "github:0xPolygonHermez/zkevm-proverjs#188654030742c3d09bac111c467869f08051a16b",
-    "@0xpolygonhermez/zkevm-testvectors": "github:0xPolygonHermez/zkevm-testvectors#feature/update-get-info",
+    "@0xpolygonhermez/zkevm-testvectors": "github:0xPolygonHermez/zkevm-testvectors#feature/error-rlp",
     "chai": "^4.3.6",
     "chalk": "^3.0.0",
     "eslint": "^8.25.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@0xpolygonhermez/zkevm-proverjs": "github:0xPolygonHermez/zkevm-proverjs#188654030742c3d09bac111c467869f08051a16b",
-    "@0xpolygonhermez/zkevm-testvectors": "github:0xPolygonHermez/zkevm-testvectors#v0.7.0.0-rc.1",
+    "@0xpolygonhermez/zkevm-testvectors": "github:0xPolygonHermez/zkevm-testvectors#feature/update-get-info",
     "chai": "^4.3.6",
     "chalk": "^3.0.0",
     "eslint": "^8.25.0",

--- a/package.json
+++ b/package.json
@@ -33,11 +33,11 @@
     "url": "https://github.com/0xPolygonHermez/zkevm-rom.git"
   },
   "dependencies": {
-    "@0xpolygonhermez/zkasmcom": "https://github.com/0xPolygonHermez/zkasmcom.git#9ca44615518218f660dd8037676d2e3eee988038",
+    "@0xpolygonhermez/zkasmcom": "https://github.com/0xPolygonHermez/zkasmcom.git#fix/non-maxmem-reg",
     "yargs": "^17.5.1"
   },
   "devDependencies": {
-    "@0xpolygonhermez/zkevm-proverjs": "github:0xPolygonHermez/zkevm-proverjs#188654030742c3d09bac111c467869f08051a16b",
+    "@0xpolygonhermez/zkevm-proverjs": "github:0xPolygonHermez/zkevm-proverjs#fix/non-maxmem-reg",
     "@0xpolygonhermez/zkevm-testvectors": "github:0xPolygonHermez/zkevm-testvectors#feature/error-rlp",
     "chai": "^4.3.6",
     "chalk": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -33,12 +33,12 @@
     "url": "https://github.com/0xPolygonHermez/zkevm-rom.git"
   },
   "dependencies": {
-    "@0xpolygonhermez/zkasmcom": "https://github.com/0xPolygonHermez/zkasmcom.git#fix/non-maxmem-reg",
+    "@0xpolygonhermez/zkasmcom": "https://github.com/0xPolygonHermez/zkasmcom.git#v0.7.0.0-rc.8-fork.1",
     "yargs": "^17.5.1"
   },
   "devDependencies": {
-    "@0xpolygonhermez/zkevm-proverjs": "github:0xPolygonHermez/zkevm-proverjs#fix/non-maxmem-reg",
-    "@0xpolygonhermez/zkevm-testvectors": "github:0xPolygonHermez/zkevm-testvectors#feature/error-rlp",
+    "@0xpolygonhermez/zkevm-proverjs": "github:0xPolygonHermez/zkevm-proverjs#864399e9e78ac6a24601c0e620909e1be02110aa",
+    "@0xpolygonhermez/zkevm-testvectors": "github:0xPolygonHermez/zkevm-testvectors#v0.7.0.0-rc.2",
     "chai": "^4.3.6",
     "chalk": "^3.0.0",
     "eslint": "^8.25.0",

--- a/test/bitwise.zkasm
+++ b/test/bitwise.zkasm
@@ -67,7 +67,7 @@ start:
     ${bitwise_not(B)}  :ASSERT
 
 
-    0 => A,B,C,D,E,CTX, SP, PC, GAS, MAXMEM, SR, HASHPOS, RR ; Set all registers to 0
+    0 => A,B,C,D,E,CTX, SP, PC, GAS,  SR, HASHPOS, RR ; Set all registers to 0
                                                                         :JMP(finalWait)
 
 INCLUDE "../main/end.zkasm"

--- a/test/comp.zkasm
+++ b/test/comp.zkasm
@@ -65,7 +65,7 @@ start:
     0 => A
     ${comp_eq(B, C)}  :ASSERT
 
-    0 => A,B,C,D,E,CTX, SP, PC, GAS, MAXMEM, SR, HASHPOS, RR ; Set all registers to 0
+    0 => A,B,C,D,E,CTX, SP, PC, GAS,  SR, HASHPOS, RR ; Set all registers to 0
                                                                         :JMP(finalWait)
 
 INCLUDE "../main/end.zkasm"

--- a/test/ecrecover.zkasm
+++ b/test/ecrecover.zkasm
@@ -423,7 +423,7 @@ repeat_ecrecover_test:
 INCLUDE "../main/ecrecover/ecrecover.zkasm"
 
 end:
-       0 => A,B,C,D,E,CTX, SP, PC, GAS, MAXMEM, SR, HASHPOS, RR, RCX
+       0 => A,B,C,D,E,CTX, SP, PC, GAS,  SR, HASHPOS, RR, RCX
 
 finalizeExecution:
 finalWait:

--- a/test/rotate.zkasm
+++ b/test/rotate.zkasm
@@ -114,7 +114,7 @@ endPushFinal:
 
 finalPush:
 
-0 => A,B,C,D,E,CTX, SP, PC, GAS, MAXMEM, SR, HASHPOS, RR ; Set all registers to 0
+0 => A,B,C,D,E,CTX, SP, PC, GAS,  SR, HASHPOS, RR ; Set all registers to 0
                                                                         :JMP(finalWait)
 
 INCLUDE "../main/end.zkasm"

--- a/test/touched-assert.zkasm
+++ b/test/touched-assert.zkasm
@@ -54,7 +54,7 @@ start:
     D => A
     0               :ASSERT
 
-    0 => A,B,C,D,E,CTX, SP, PC, GAS, MAXMEM, SR, HASHPOS, RR ; Set all registers to 0
+    0 => A,B,C,D,E,CTX, SP, PC, GAS,  SR, HASHPOS, RR ; Set all registers to 0
     finalizeExecution:
                                                                         :JMP(finalWait)
 

--- a/test/utils-expAD.zkasm
+++ b/test/utils-expAD.zkasm
@@ -42,7 +42,7 @@ start:
     0xf2eda75a1e9624437a4f18c1316372866f14b6bf3f7ff7441996f65b747a0001n => A
     $                 :MLOAD(test),ASSERT
 
-0 => A,B,C,D,E,CTX, SP, PC, GAS, MAXMEM, SR, HASHPOS, RR ; Set all registers to 0
+0 => A,B,C,D,E,CTX, SP, PC, GAS,  SR, HASHPOS, RR ; Set all registers to 0
                                                             :JMP(finalWait)
 
 INCLUDE "../main/main.zkasm"

--- a/test/utils-getLenBytes.zkasm
+++ b/test/utils-getLenBytes.zkasm
@@ -30,7 +30,7 @@ start:
     6 => A
     $                 :MLOAD(test),ASSERT
 
-0 => A,B,C,D,E,CTX, SP, PC, GAS, MAXMEM, SR, HASHPOS, RR ; Set all registers to 0
+0 => A,B,C,D,E,CTX, SP, PC, GAS,  SR, HASHPOS, RR ; Set all registers to 0
                                                             :JMP(finalWait)
 
 INCLUDE "../main/main.zkasm"


### PR DESCRIPTION
This PR does the following:
- fixes adding correct bytes to `batchHashData` when non-canonical RLP error is found
- remove `MAXMEM` resgister