### PR TITLE
Add folder name at parallel test generation to avoid name collisions

### DIFF
--- a/main/utils.zkasm
+++ b/main/utils.zkasm
@@ -135,7 +135,7 @@ __MSTOREX_afterSave:
 
         ; E === 32 * RR + A (RCX)
         ; E - 32 * RR === A
-        ; secure: E < MAX_MEM_EXPASION_BYTES < 32 bits, RR < 32 bits, 32*RR < 37 bits, all < 38 bits
+        ; secure: E < MAX_MEM_EXPANSION_BYTES < 32 bits, RR < 32 bits, 32*RR < 37 bits, all < 38 bits
         E - 32 * RR                 :ASSERT
 
         RCX + %MEM_ALIGN_LEN * C + %MEM_ALIGN_LEFT_ALIGNMENT => C     :JMP_EQ(%MEM_ALIGN_LEN * 32 + %MEM_ALIGN_LEFT_ALIGNMENT, __MSTORE32_offset0_len32)

--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
   },
   "devDependencies": {
     "@0xpolygonhermez/zkevm-commonjs": "github:0xPolygonHermez/zkevm-commonjs#v7.0.0-rc.1-fork.10",
-    "@0xpolygonhermez/zkevm-proverjs": "github:0xPolygonHermez/zkevm-proverjs#feature/renaming",
-    "@0xpolygonhermez/zkevm-testvectors": "github:0xPolygonHermez/zkevm-testvectors#v7.0.0-rc.1-fork.10",
+    "@0xpolygonhermez/zkevm-proverjs": "github:0xPolygonHermez/zkevm-proverjs#feature/fix-batchHashData",
+    "@0xpolygonhermez/zkevm-testvectors": "github:0xPolygonHermez/zkevm-testvectors#feature/fix-test",
     "chai": "^4.3.6",
     "chalk": "^3.0.0",
     "eslint": "^8.25.0",

--- a/tools/parallel-testing/gen-parallel-tests.js
+++ b/tools/parallel-testing/gen-parallel-tests.js
@@ -25,14 +25,15 @@ async function genTestsFiles() {
         fs.mkdirSync(testsFolder);
     }
     for (const inputPath of inputs) {
-        const name = inputPath.split('/').slice(-1)[0].replace('json', 'test.js');
+        const fileName = path.basename(inputPath, '.json');
+        const folderName = path.basename(path.dirname(inputPath));
         const sample = fs.readFileSync(sampleDir, 'utf-8');
         let test = sample.replace('%%INPUT_PATH%%', `${inputPath}`);
         // Replace skip vcounters flag
         if (argv.skipVCounters) {
             test = test.replace('%%SKIP_VCOUNTERS%%', 'yes');
         }
-        fs.writeFileSync(`${testsFolder}/${name}`, test);
+        fs.writeFileSync(`${testsFolder}/${folderName}__${fileName}.test.js`, test);
     }
     expect(true).to.be.equal(true);
 }


### PR DESCRIPTION
Add folder name at parallel test generation to avoid name collisions