### PR TITLE
Durian audit fixes

### DIFF
--- a/main/p256verify/dblScalarMulSecp256r1.zkasm
+++ b/main/p256verify/dblScalarMulSecp256r1.zkasm
@@ -364,7 +364,7 @@ dblScalarMulSecp256r1_save_k10_k21:
 ;     if (latch == 0):
 ;         print("\t$ => C\t\t\t:MLOAD(dblScalarMulSecp256r1_acum_k1), JMP(dblScalarMulSecp256r1_save_k10_k20)  ; RR = {}".format(i))
 ;     else:
-;         print("\tRR - 1 => RR\t:JMPN(dblScalarMulSecp256r1_end_loop,dblScalarMulSecp256r1_double_noRR)\t\t\t; RR = {}".format(i))
+;         print("\tRR - 1 => RR\t:JMPN(dblScalarMulSecp256r1_end_loop,dblScalarMulSecp256r1_double_noRR)\t\t\t; RR = {}".format(i)) # RR - 1 >= 0, but we leave the JMPN for understanding
 ; ----------------------------------------
 dblScalarMulSecp256r1_scalar_table_k10_k20:
 	$ => C			:MLOAD(dblScalarMulSecp256r1_acum_k1), JMP(dblScalarMulSecp256r1_save_k10_k20)  ; RR = 0

--- a/main/p256verify/p256verify.zkasm
+++ b/main/p256verify/p256verify.zkasm
@@ -101,7 +101,7 @@ p256verify_correctness_checks:
         $ => B          :MLOAD(p256verify_y)
         $               :LT, JMPC(p256verify_error_y_is_too_big)
 
-        ; 5] Check whether PK = (x,y) is the point at infinity 𝒪
+        ; 5] Early return if PK = (x,y) is the point at infinity 𝒪 := (0,0). This condition would also be caught by the following elliptic curve equation check.
         0n => B
         $ => A          :MLOAD(p256verify_x)
         $               :EQ, JMPNC(p256verify_pk_not_point_at_infinity)


### PR DESCRIPTION
This pull request includes minor changes to comments in the `dblScalarMulSecp256r1_save_k10_k21` and `p256verify_correctness_checks` tags:

* [`main/p256verify/dblScalarMulSecp256r1.zkasm`](diffhunk://#diff-ff4691bf6d948b711fb89de300c258462e9a70eff957b268b42c57cea9ca29e5L367-R367): Added a comment to explain that the `JMPN` instruction is left for understanding purposes, even though `RR - 1 >= 0`.
* [`main/p256verify/p256verify.zkasm`](diffhunk://#diff-d7e65911bdf0162df4016a2d8146c5b3acc3e75c017edb0cf9db6ca3b8125752L104-R104): Updated the comment to clarify that an early return is performed if `PK = (x,y)` is the point at infinity `(0,0)`, which would also be caught by the elliptic curve equation check.